### PR TITLE
Add nuspec files for tool packages to support code signing

### DIFF
--- a/Accordant.Cli/Accordant.Cli.csproj
+++ b/Accordant.Cli/Accordant.Cli.csproj
@@ -8,11 +8,8 @@
     <Nullable>enable</Nullable>
     <RootNamespace>Microsoft.Accordant.Cli</RootNamespace>
     
-    <!-- dotnet tool configuration -->
-    <PackAsTool>true</PackAsTool>
-    <ToolCommandName>accordant</ToolCommandName>
-    <PackageId>Microsoft.Accordant.Cli</PackageId>
-    <Description>CLI tool for scaffolding Accordant model-based testing projects</Description>
+    <!-- Source project only - Microsoft.Accordant.Cli is the published package -->
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Accordant.StateSourceCodeGenerator/Accordant.StateSourceCodeGenerator.csproj
+++ b/Accordant.StateSourceCodeGenerator/Accordant.StateSourceCodeGenerator.csproj
@@ -5,11 +5,8 @@
 		<OutputType>Exe</OutputType>
 		<OutputPath>../bin/tools/Accordant.StateSourceCodeGenerator</OutputPath>
 		
-		<!-- dotnet tool configuration -->
-		<PackAsTool>true</PackAsTool>
-		<ToolCommandName>accordant-stategen</ToolCommandName>
-		<PackageId>Microsoft.Accordant.StateSourceCodeGenerator</PackageId>
-		<Description>State source code generator for Accordant model-based testing</Description>
+		<!-- Source project only - Microsoft.Accordant.StateSourceCodeGenerator is the published package -->
+		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Microsoft.Accordant.Cli/Microsoft.Accordant.Cli.csproj
+++ b/Microsoft.Accordant.Cli/Microsoft.Accordant.Cli.csproj
@@ -8,11 +8,8 @@
     <Nullable>enable</Nullable>
     <RootNamespace>Microsoft.Accordant</RootNamespace>
     
-    <!-- dotnet tool configuration -->
-    <PackAsTool>true</PackAsTool>
-    <ToolCommandName>accordant</ToolCommandName>
-    <PackageId>Microsoft.Accordant.Cli</PackageId>
-    <Description>CLI tool for scaffolding Accordant model-based testing projects</Description>
+    <!-- Tool is packaged via Scripts/NuGet/Microsoft.Accordant.Cli.nuspec -->
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Microsoft.Accordant.StateSourceCodeGenerator/Microsoft.Accordant.StateSourceCodeGenerator.csproj
+++ b/Microsoft.Accordant.StateSourceCodeGenerator/Microsoft.Accordant.StateSourceCodeGenerator.csproj
@@ -6,11 +6,8 @@
 		<OutputPath>../bin/tools/Microsoft.Accordant.StateSourceCodeGenerator</OutputPath>
 		<RootNamespace>Microsoft.Accordant</RootNamespace>
 		
-		<!-- dotnet tool configuration -->
-		<PackAsTool>true</PackAsTool>
-		<ToolCommandName>accordant-stategen</ToolCommandName>
-		<PackageId>Microsoft.Accordant.StateSourceCodeGenerator</PackageId>
-		<Description>State source code generator for Accordant model-based testing</Description>
+		<!-- Tool is packaged via Scripts/NuGet/Microsoft.Accordant.StateSourceCodeGenerator.nuspec -->
+		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/nuget/Microsoft.Accordant.Cli.nuspec
+++ b/nuget/Microsoft.Accordant.Cli.nuspec
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <metadata>
+    <id>Microsoft.Accordant.Cli</id>
+    <version>0.1.0-preview</version>
+    <authors>Microsoft</authors>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <repository type="git" url="https://github.com/microsoft/accordant"/>
+    <description>CLI tool for scaffolding Accordant model-based testing projects</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <tags>accordant cli scaffolding testing model-based</tags>
+    <packageTypes>
+      <packageType name="DotnetTool" />
+    </packageTypes>
+  </metadata>
+  <files>
+    <!-- net9.0 -->
+    <file src="..\bin\tools\Microsoft.Accordant.Cli\net9.0\publish\*.*" target="tools\net9.0\any" />
+    
+    <!-- net8.0 -->
+    <file src="..\bin\tools\Microsoft.Accordant.Cli\net8.0\publish\*.*" target="tools\net8.0\any" />
+    
+    <!-- net7.0 -->
+    <file src="..\bin\tools\Microsoft.Accordant.Cli\net7.0\publish\*.*" target="tools\net7.0\any" />
+    
+    <!-- net6.0 -->
+    <file src="..\bin\tools\Microsoft.Accordant.Cli\net6.0\publish\*.*" target="tools\net6.0\any" />
+  </files>
+</package>

--- a/nuget/Microsoft.Accordant.StateSourceCodeGenerator.nuspec
+++ b/nuget/Microsoft.Accordant.StateSourceCodeGenerator.nuspec
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <metadata>
+    <id>Microsoft.Accordant.StateSourceCodeGenerator</id>
+    <version>0.1.0-preview</version>
+    <authors>Microsoft</authors>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <repository type="git" url="https://github.com/microsoft/accordant"/>
+    <description>State source code generator for Accordant model-based testing</description>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <tags>accordant state generator testing model-based</tags>
+    <packageTypes>
+      <packageType name="DotnetTool" />
+    </packageTypes>
+  </metadata>
+  <files>
+    <!-- net9.0 -->
+    <file src="..\bin\tools\Microsoft.Accordant.StateSourceCodeGenerator\net9.0\publish\*.*" target="tools\net9.0\any" />
+    
+    <!-- net8.0 -->
+    <file src="..\bin\tools\Microsoft.Accordant.StateSourceCodeGenerator\net8.0\publish\*.*" target="tools\net8.0\any" />
+    
+    <!-- net7.0 -->
+    <file src="..\bin\tools\Microsoft.Accordant.StateSourceCodeGenerator\net7.0\publish\*.*" target="tools\net7.0\any" />
+    
+    <!-- net6.0 -->
+    <file src="..\bin\tools\Microsoft.Accordant.StateSourceCodeGenerator\net6.0\publish\*.*" target="tools\net6.0\any" />
+  </files>
+</package>


### PR DESCRIPTION
- Add nuget/Microsoft.Accordant.Cli.nuspec
- Add nuget/Microsoft.Accordant.StateSourceCodeGenerator.nuspec
- Remove PackAsTool from tool csproj files (nuspec handles packaging)
- Set IsPackable=false on source-only Accordant.* projects

This enables signed binaries to be packaged correctly in OneBranch pipelines by using explicit nuspec files that reference the signed publish output instead of dotnet pack regenerating unsigned files.