### PR TITLE
Fix terminal step function polling + add TriggersWhen API

### DIFF
--- a/Accordant.Operations/Expect.cs
+++ b/Accordant.Operations/Expect.cs
@@ -555,6 +555,58 @@ namespace Microsoft.Accordant
             return this;
         }
 
+        /// <summary>
+        /// Specifies that this operation conditionally triggers a step function based on the response.
+        /// The step function is only triggered when the predicate returns true.
+        /// </summary>
+        /// <param name="predicate">A function that returns true when the step function should be triggered.</param>
+        /// <param name="stepFunction">The step function to trigger when the predicate is true.</param>
+        /// <returns>This builder for method chaining.</returns>
+        public ExpectedOutcomeBuilder<TResponse> TriggersWhen(
+            Func<TResponse, bool> predicate,
+            IStepFunction stepFunction)
+        {
+            if (predicate == null)
+                throw new ArgumentNullException(nameof(predicate));
+            if (stepFunction == null)
+                throw new ArgumentNullException(nameof(stepFunction));
+
+            _nextStepFunctions = (resp) =>
+            {
+                var typedResp = (TResponse)resp;
+                return predicate(typedResp)
+                    ? new StepFunctionList(stepFunction)
+                    : new StepFunctionList();
+            };
+            return this;
+        }
+
+        /// <summary>
+        /// Specifies that this operation conditionally triggers multiple step functions based on the response.
+        /// The step functions are only triggered when the predicate returns true.
+        /// </summary>
+        /// <param name="predicate">A function that returns true when the step functions should be triggered.</param>
+        /// <param name="stepFunctions">The step functions to trigger when the predicate is true.</param>
+        /// <returns>This builder for method chaining.</returns>
+        public ExpectedOutcomeBuilder<TResponse> TriggersWhen(
+            Func<TResponse, bool> predicate,
+            params IStepFunction[] stepFunctions)
+        {
+            if (predicate == null)
+                throw new ArgumentNullException(nameof(predicate));
+            if (stepFunctions == null || stepFunctions.Length == 0)
+                throw new ArgumentException("At least one step function must be provided.", nameof(stepFunctions));
+
+            _nextStepFunctions = (resp) =>
+            {
+                var typedResp = (TResponse)resp;
+                return predicate(typedResp)
+                    ? new StepFunctionList(stepFunctions)
+                    : new StepFunctionList();
+            };
+            return this;
+        }
+
         #endregion
 
         #region Build

--- a/Accordant.Operations/ExpectContext.cs
+++ b/Accordant.Operations/ExpectContext.cs
@@ -312,6 +312,36 @@ namespace Microsoft.Accordant
             return this;
         }
 
+        /// <summary>
+        /// Specifies that this operation conditionally triggers a step function based on the response.
+        /// The step function is only triggered when the predicate returns true.
+        /// </summary>
+        /// <param name="predicate">A function that returns true when the step function should be triggered.</param>
+        /// <param name="stepFunction">The step function to trigger when the predicate is true.</param>
+        /// <returns>This builder for method chaining.</returns>
+        public TypedExpectBuilder<TResponse, TState> TriggersWhen(
+            Func<TResponse, bool> predicate,
+            IStepFunction stepFunction)
+        {
+            _inner.TriggersWhen(predicate, stepFunction);
+            return this;
+        }
+
+        /// <summary>
+        /// Specifies that this operation conditionally triggers multiple step functions based on the response.
+        /// The step functions are only triggered when the predicate returns true.
+        /// </summary>
+        /// <param name="predicate">A function that returns true when the step functions should be triggered.</param>
+        /// <param name="stepFunctions">The step functions to trigger when the predicate is true.</param>
+        /// <returns>This builder for method chaining.</returns>
+        public TypedExpectBuilder<TResponse, TState> TriggersWhen(
+            Func<TResponse, bool> predicate,
+            params IStepFunction[] stepFunctions)
+        {
+            _inner.TriggersWhen(predicate, stepFunctions);
+            return this;
+        }
+
         #endregion
 
         #region Build

--- a/Accordant.Operations/TestCaseExecutor.cs
+++ b/Accordant.Operations/TestCaseExecutor.cs
@@ -869,6 +869,10 @@ namespace Microsoft.Accordant
 
         /// <summary>
         /// Gets the list of TerminatingStepFunction instances that should be polled for.
+        /// Only includes step functions that have NOT yet reached their terminal state.
+        /// Note: The state profile can have multiple entries with the same state but different
+        /// step functions (due to non-determinism). We filter out terminal ones to avoid
+        /// spurious polling on subsequent operations.
         /// </summary>
         private static HashSet<TerminatingStepFunction> GetStepFunctionsToPollFor(
             StateProfile stateProfile)
@@ -879,7 +883,8 @@ namespace Microsoft.Accordant
             {
                 foreach (var sf in stepFunctions)
                 {
-                    if (sf is TerminatingStepFunction tsf)
+                    // Only include step functions that haven't reached their terminal state yet.
+                    if (sf is TerminatingStepFunction tsf && !tsf.IsTerminalState(state))
                     {
                         result.Add(tsf);
                     }

--- a/Accordant/StepFunction/IStepFunction.cs
+++ b/Accordant/StepFunction/IStepFunction.cs
@@ -145,13 +145,15 @@ namespace Microsoft.Accordant
         /// <summary>
         /// Sealed implementation that handles the terminal check automatically.
         /// Only calls <see cref="GetStepResults"/> when the state is not terminal.
+        /// When terminal, returns the current state unchanged to consume the step function
+        /// (removing it from the state profile).
         /// </summary>
         protected sealed override IList<StepResult> ApplyInternal(IState state)
         {
-            // Already terminal? Nothing to do.
+            // Already terminal? Return same state to consume ourselves (get removed from state profile).
             if (IsTerminalState(state))
             {
-                return null;
+                return new[] { new StepResult { State = state } };
             }
 
             return GetStepResults(state);

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     
     <!-- NuGet Package Defaults -->
-    <Version>0.1.1-preview</Version>
+    <Version>0.1.2-preview</Version>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
     <Copyright>Copyright (c) 2024-2026 Microsoft Corporation</Copyright>

--- a/Tests/Accordant.Operations.Tests/ExpectTests.cs
+++ b/Tests/Accordant.Operations.Tests/ExpectTests.cs
@@ -999,6 +999,103 @@ namespace Microsoft.Accordant.Operations.Tests
 
         #endregion
 
+        #region TriggersWhen Tests
+
+        [Test]
+        public void Expect_TriggersWhen_PredicateTrue_IncludesStepFunction()
+        {
+            var stepFunction = new TestStepFunction(42);
+            var state = new CounterState(1);
+
+            ExpectedOutcome outcome = Expect.That<int>(r => true, "valid")
+                                            .SameState()
+                                            .TriggersWhen(r => r > 0, stepFunction);
+
+            var (isValid, stateProfile) = outcome.Matches(5, state);
+
+            Assert.IsTrue(isValid);
+            var stepFunctions = stateProfile.StatesAndStepFunctions[0].Item2;
+            Assert.AreEqual(1, stepFunctions.Count);
+            Assert.AreSame(stepFunction, stepFunctions[0]);
+        }
+
+        [Test]
+        public void Expect_TriggersWhen_PredicateFalse_NoStepFunction()
+        {
+            var stepFunction = new TestStepFunction(42);
+            var state = new CounterState(1);
+
+            ExpectedOutcome outcome = Expect.That<int>(r => true, "valid")
+                                            .SameState()
+                                            .TriggersWhen(r => r < 0, stepFunction);  // false for positive response
+
+            var (isValid, stateProfile) = outcome.Matches(5, state);
+
+            Assert.IsTrue(isValid);
+            var stepFunctions = stateProfile.StatesAndStepFunctions[0].Item2;
+            Assert.AreEqual(0, stepFunctions.Count);  // No step function triggered
+        }
+
+        [Test]
+        public void Expect_TriggersWhen_NullPredicateThrows()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                Expect.That<int>(r => true, "valid")
+                      .SameState()
+                      .TriggersWhen(null, new TestStepFunction(1));
+            });
+        }
+
+        [Test]
+        public void Expect_TriggersWhen_NullStepFunctionThrows()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                Expect.That<int>(r => true, "valid")
+                      .SameState()
+                      .TriggersWhen(r => true, (IStepFunction)null);
+            });
+        }
+
+        [Test]
+        public void Expect_TriggersWhen_MultipleStepFunctions_PredicateTrue_IncludesAll()
+        {
+            var sf1 = new TestStepFunction(1);
+            var sf2 = new TestStepFunction(2);
+            var state = new CounterState(1);
+
+            ExpectedOutcome outcome = Expect.That<int>(r => true, "valid")
+                                            .SameState()
+                                            .TriggersWhen(r => r > 0, sf1, sf2);
+
+            var (isValid, stateProfile) = outcome.Matches(5, state);
+
+            Assert.IsTrue(isValid);
+            var stepFunctions = stateProfile.StatesAndStepFunctions[0].Item2;
+            Assert.AreEqual(2, stepFunctions.Count);
+        }
+
+        [Test]
+        public void Expect_TriggersWhen_MultipleStepFunctions_PredicateFalse_NoStepFunctions()
+        {
+            var sf1 = new TestStepFunction(1);
+            var sf2 = new TestStepFunction(2);
+            var state = new CounterState(1);
+
+            ExpectedOutcome outcome = Expect.That<int>(r => true, "valid")
+                                            .SameState()
+                                            .TriggersWhen(r => r < 0, sf1, sf2);
+
+            var (isValid, stateProfile) = outcome.Matches(5, state);
+
+            Assert.IsTrue(isValid);
+            var stepFunctions = stateProfile.StatesAndStepFunctions[0].Item2;
+            Assert.AreEqual(0, stepFunctions.Count);
+        }
+
+        #endregion
+
         #region Additional Null Validation Tests
 
         [Test]

--- a/Tests/Accordant.Operations.Tests/SampleClasses.cs
+++ b/Tests/Accordant.Operations.Tests/SampleClasses.cs
@@ -387,4 +387,366 @@ namespace Microsoft.Accordant.Operations.Tests
             return new[] { new StepResult { State = nextState } };
         }
     }
+
+    #region TerminalStepFunctionPolling Bug Repro
+
+    /// <summary>
+    /// State for the async operation scenario.
+    /// Models a resource with a Status that transitions from "pending" to "success".
+    /// </summary>
+    [State]
+    public partial class AsyncOperationState : State
+    {
+        public string Status { get; set; } = "none";
+    }
+
+    /// <summary>
+    /// Spec for reproducing the bug where a terminated step function
+    /// causes polling to be attempted on subsequent operations that
+    /// don't have polling configured.
+    /// 
+    /// Models: StartAsync -> GetStatus (polls until success) -> Unrelated operation (no polling)
+    /// </summary>
+    public class AsyncOperationSpec : Spec<AsyncOperationState>
+    {
+        public StartAsyncOperation StartAsync { get; } = new();
+        public GetStatusOperation GetStatus { get; } = new();
+        public UnrelatedOperation Unrelated { get; } = new();
+
+        public AsyncOperationSpec()
+        {
+            this["StartAsync"] = StartAsync;
+            this["GetStatus"] = GetStatus;
+            this["Unrelated"] = Unrelated;
+        }
+    }
+
+    /// <summary>
+    /// StartAsync operation - triggers async work, returns while work is still pending.
+    /// Has polling configured to poll via GetStatus.
+    /// </summary>
+    public class StartAsyncOperation : Operation<Unit, string, AsyncOperationState>
+    {
+        public StartAsyncOperation() : base("StartAsync") { }
+
+        public override PollingSetup Polling => new PollingSetup
+        {
+            Operation = "GetStatus",
+            WaitTimeInMs = 10,
+            MaxRetryCount = 100
+        };
+
+        public override ExpectedOutcomes Apply(Unit request, AsyncOperationState state)
+        {
+            if (state.Status != "none")
+            {
+                return Expect.That(r => r == "already started", "already started").SameState();
+            }
+
+            // Work starts in "pending" state and triggers a step function
+            // that will eventually transition to "success"
+            return Expect.That(r => r == "pending", "work started, status is pending")
+                         .WithNextState(new AsyncOperationState { Status = "pending" })
+                         .Triggers(new AsyncWorkStepFunction());
+        }
+
+        public override string Execute(TestingContext context, Unit request)
+        {
+            var target = context.Get<AsyncWorkTarget>();
+            return target.StartWork();
+        }
+    }
+
+    /// <summary>
+    /// GetStatus - observes the current status from the server.
+    /// Uses state-aware validation: asserts response matches model state.
+    /// The step function is responsible for transitioning state to "success".
+    /// </summary>
+    public class GetStatusOperation : Operation<Unit, string, AsyncOperationState>
+    {
+        public GetStatusOperation() : base("GetStatus") { }
+
+        /// <summary>
+        /// Derivation for polling: GetStatus derives from StartAsync.
+        /// </summary>
+        public override IReadOnlyList<RequestDerivation> DerivedFrom => new[]
+        {
+            Derive.From<Unit, string, Unit>("StartAsync")
+                  .As((req, resp) => Unit.Value)
+        };
+
+        public override ExpectedOutcomes Apply(Unit request, AsyncOperationState state)
+        {
+            // State-aware validation: assert response matches our model state.
+            // The step function is responsible for transitioning state to "success".
+            return Expect.That(r => r == state.Status, $"should return '{state.Status}'")
+                         .SameState();
+        }
+
+        public override string Execute(TestingContext context, Unit request)
+        {
+            return context.Get<AsyncWorkTarget>().GetStatus();
+        }
+    }
+
+    /// <summary>
+    /// Unrelated operation - does NOT have polling configured.
+    /// </summary>
+    public class UnrelatedOperation : Operation<Unit, string, AsyncOperationState>
+    {
+        public UnrelatedOperation() : base("Unrelated") { }
+
+        // NOTE: No Polling property - this operation has nothing to do with async work.
+
+        public override ExpectedOutcomes Apply(Unit request, AsyncOperationState state)
+        {
+            return Expect.That(r => r == "ok", "unrelated operation completed")
+                         .SameState();
+        }
+
+        public override string Execute(TestingContext context, Unit request)
+        {
+            return context.Get<AsyncWorkTarget>().DoUnrelatedWork();
+        }
+    }
+
+    /// <summary>
+    /// Step function that models the async work completing.
+    /// Terminal when Status is no longer "pending" (i.e., "success" or "failed").
+    /// </summary>
+    public class AsyncWorkStepFunction : TerminatingStepFunction
+    {
+        public override Func<IState, bool> IsTerminalState => state =>
+        {
+            var asyncState = (AsyncOperationState)state;
+            // Terminal when work is no longer pending
+            return asyncState.Status != "pending";
+        };
+
+        protected override IList<StepResult> GetStepResults(IState state)
+        {
+            // Transition from pending to success
+            var nextState = (AsyncOperationState)state.Clone();
+            nextState.Status = "success";
+            return new[] { new StepResult { State = nextState } };
+        }
+    }
+
+    /// <summary>
+    /// Target class that simulates async work.
+    /// </summary>
+    public class AsyncWorkTarget
+    {
+        private string status = "none";
+
+        public string StartWork()
+        {
+            if (status == "none")
+            {
+                status = "pending";
+                // Simulate async work completing quickly
+                _ = Task.Run(async () =>
+                {
+                    await Task.Delay(5);
+                    status = "success";
+                });
+            }
+            return status;
+        }
+
+        public string GetStatus() => status;
+
+        public string DoUnrelatedWork() => "ok";
+    }
+
+    #endregion
+
+    #region TriggersWhen Demo - CopyBlob-like Scenario
+
+    /// <summary>
+    /// State for the copy operation scenario.
+    /// Models a resource that can complete immediately ("success") or async ("pending").
+    /// </summary>
+    [State]
+    public partial class CopyState : State
+    {
+        public string CopyStatus { get; set; } = "none";
+    }
+
+    /// <summary>
+    /// Spec demonstrating TriggersWhen for operations that may or may not trigger
+    /// async work depending on the response.
+    /// 
+    /// Like Azure Blob Copy: operation can return "success" (copy completed immediately)
+    /// or "pending" (copy is async, need to poll).
+    /// </summary>
+    public class CopyOperationSpec : Spec<CopyState>
+    {
+        public StartCopyOperation StartCopy { get; } = new();
+        public GetCopyStatusOperation GetCopyStatus { get; } = new();
+        public UnrelatedCopyOperation UnrelatedCopy { get; } = new();
+
+        public CopyOperationSpec()
+        {
+            this["StartCopy"] = StartCopy;
+            this["GetCopyStatus"] = GetCopyStatus;
+            this["UnrelatedCopy"] = UnrelatedCopy;
+        }
+    }
+
+    /// <summary>
+    /// StartCopy - models an operation that can complete immediately or async.
+    /// Uses TriggersWhen to only trigger the step function when response is "pending".
+    /// </summary>
+    public class StartCopyOperation : Operation<Unit, string, CopyState>
+    {
+        public StartCopyOperation() : base("StartCopy") { }
+
+        public override PollingSetup Polling => new PollingSetup
+        {
+            Operation = "GetCopyStatus",
+            WaitTimeInMs = 10,
+            MaxRetryCount = 100
+        };
+
+        public override ExpectedOutcomes Apply(Unit request, CopyState state)
+        {
+            if (state.CopyStatus != "none")
+            {
+                return Expect.That(r => r == "already started", "already started").SameState();
+            }
+
+            // Response can be either "pending" (async) or "success" (immediate completion)
+            // Only trigger step function when pending!
+            return Expect.That(r => r == "pending" || r == "success", "copy started")
+                         .ThenState(
+                             (string response, CopyState nextState) =>
+                             {
+                                 nextState.CopyStatus = response;
+                             },
+                             mock: () => "success")  // Mock returns success for exploration
+                         .TriggersWhen(
+                             response => response == "pending",
+                             new CopyStepFunction());
+        }
+
+        public override string Execute(TestingContext context, Unit request)
+        {
+            return context.Get<CopyTarget>().StartCopy();
+        }
+    }
+
+    /// <summary>
+    /// GetCopyStatus - polls for copy completion using response-dependent state.
+    /// </summary>
+    public class GetCopyStatusOperation : Operation<Unit, string, CopyState>
+    {
+        public GetCopyStatusOperation() : base("GetCopyStatus") { }
+
+        public override IReadOnlyList<RequestDerivation> DerivedFrom => new[]
+        {
+            Derive.From<Unit, string, Unit>("StartCopy")
+                  .As((req, resp) => Unit.Value)
+        };
+
+        public override ExpectedOutcomes Apply(Unit request, CopyState state)
+        {
+            // Response-dependent state: accept pending or success, update model
+            return Expect.That(r => r == "pending" || r == "success", "should return copy status")
+                         .ThenState(
+                             (string response, CopyState nextState) =>
+                             {
+                                 nextState.CopyStatus = response;
+                             },
+                             mock: () => "success");
+        }
+
+        public override string Execute(TestingContext context, Unit request)
+        {
+            return context.Get<CopyTarget>().GetCopyStatus();
+        }
+    }
+
+    /// <summary>
+    /// Unrelated operation - no polling configured.
+    /// </summary>
+    public class UnrelatedCopyOperation : Operation<Unit, string, CopyState>
+    {
+        public UnrelatedCopyOperation() : base("UnrelatedCopy") { }
+
+        public override ExpectedOutcomes Apply(Unit request, CopyState state)
+        {
+            return Expect.That(r => r == "ok", "unrelated completed").SameState();
+        }
+
+        public override string Execute(TestingContext context, Unit request)
+        {
+            return context.Get<CopyTarget>().DoUnrelated();
+        }
+    }
+
+    /// <summary>
+    /// Step function for copy completion - terminal when CopyStatus != "pending".
+    /// </summary>
+    public class CopyStepFunction : TerminatingStepFunction
+    {
+        public override Func<IState, bool> IsTerminalState => state =>
+        {
+            var copyState = (CopyState)state;
+            return copyState.CopyStatus != "pending";
+        };
+
+        protected override IList<StepResult> GetStepResults(IState state)
+        {
+            var nextState = (CopyState)state.Clone();
+            nextState.CopyStatus = "success";
+            return new[] { new StepResult { State = nextState } };
+        }
+    }
+
+    /// <summary>
+    /// Target that simulates copy operation behavior.
+    /// </summary>
+    public class CopyTarget
+    {
+        private string copyStatus = "none";
+        private readonly bool immediateSuccess;
+
+        /// <summary>
+        /// Creates a copy target.
+        /// </summary>
+        /// <param name="immediateSuccess">If true, StartCopy returns "success" immediately.
+        /// If false, returns "pending" and completes asynchronously.</param>
+        public CopyTarget(bool immediateSuccess = true)
+        {
+            this.immediateSuccess = immediateSuccess;
+        }
+
+        public string StartCopy()
+        {
+            if (copyStatus == "none")
+            {
+                if (immediateSuccess)
+                {
+                    copyStatus = "success";
+                }
+                else
+                {
+                    copyStatus = "pending";
+                    _ = Task.Run(async () =>
+                    {
+                        await Task.Delay(5);
+                        copyStatus = "success";
+                    });
+                }
+            }
+            return copyStatus;
+        }
+
+        public string GetCopyStatus() => copyStatus;
+
+        public string DoUnrelated() => "ok";
+    }
+
+    #endregion
 }

--- a/Tests/Accordant.Operations.Tests/TestExecutorTests.cs
+++ b/Tests/Accordant.Operations.Tests/TestExecutorTests.cs
@@ -1062,5 +1062,149 @@ namespace Microsoft.Accordant.Operations.Tests
             Assert.AreEqual(testCases.Count, afterEachCalls, "AfterEach should be called for each concurrent test");
             Assert.IsTrue(onStepExecutedCalls > 0, "OnStepExecuted should be called for concurrent tests");
         }
+
+        /// <summary>
+        /// Test that a terminal step function does not cause spurious polling
+        /// on subsequent operations that don't have polling configured.
+        /// 
+        /// Scenario:
+        /// 1. StartAsync triggers async work, returns "pending", triggers step function
+        /// 2. GetStatus polls and step function fires, transitioning to "success"
+        /// 3. Unrelated operation runs (no polling configured)
+        /// 4. Should not attempt to poll for Unrelated
+        /// </summary>
+        [Test]
+        public async Task TerminalStepFunction_ShouldNotTriggerPollingOnSubsequentOperations()
+        {
+            var spec = new AsyncOperationSpec();
+            var initialState = new AsyncOperationState { Status = "none" };
+
+            var inputSet = new InputSet()
+            {
+                new OperationInput("StartAsync", spec["StartAsync"]),
+                new OperationInput("Unrelated", spec["Unrelated"]),
+            };
+
+            // Create a manual test case: StartAsync -> Unrelated
+            var testCase = TestCaseGenerator.CreateManualSequentialTestCase(
+                spec.CreateTestingContext(),
+                inputSet,
+                "StartAsync", "Unrelated");
+
+            var context = spec.CreateTestingContext();
+
+            // Run the test - this should NOT throw a PollingException
+            var results = await spec.RunTests(
+                context,
+                initialState,
+                new[] { testCase },
+                new TestExecutionOptions
+                {
+                    BeforeEach = _ => context.Register(new AsyncWorkTarget())
+                });
+
+            // Provide detailed failure information
+            var failedResults = results.Where(r => !r.Success).ToList();
+            if (failedResults.Any())
+            {
+                var messages = string.Join("\n", failedResults.Select(r => r.LastFailureMessage));
+                Assert.Fail($"Test failed with messages:\n{messages}");
+            }
+
+            // The test should pass without throwing PollingException
+            Assert.IsTrue(results.All(r => r.Success), 
+                "Test should pass - Unrelated operation should not trigger polling " +
+                "just because a previous step function is still (terminally) in the state profile");
+        }
+
+        /// <summary>
+        /// Test that TriggersWhen correctly avoids triggering step function when response
+        /// indicates immediate completion (like CopyBlob returning "success" immediately).
+        /// </summary>
+        [Test]
+        public async Task TriggersWhen_ImmediateSuccess_NoStepFunctionTriggered()
+        {
+            var spec = new CopyOperationSpec();
+            var initialState = new CopyState { CopyStatus = "none" };
+
+            var inputSet = new InputSet()
+            {
+                new OperationInput("StartCopy", spec["StartCopy"]),
+                new OperationInput("UnrelatedCopy", spec["UnrelatedCopy"]),
+            };
+
+            var testCase = TestCaseGenerator.CreateManualSequentialTestCase(
+                spec.CreateTestingContext(),
+                inputSet,
+                "StartCopy", "UnrelatedCopy");
+
+            var context = spec.CreateTestingContext();
+
+            // Use CopyTarget with immediateSuccess=true - StartCopy returns "success" immediately
+            // TriggersWhen should NOT trigger the step function
+            var results = await spec.RunTests(
+                context,
+                initialState,
+                new[] { testCase },
+                new TestExecutionOptions
+                {
+                    BeforeEach = _ => context.Register(new CopyTarget(immediateSuccess: true))
+                });
+
+            var failedResults = results.Where(r => !r.Success).ToList();
+            if (failedResults.Any())
+            {
+                var messages = string.Join("\n", failedResults.Select(r => r.LastFailureMessage));
+                Assert.Fail($"Test failed with messages:\n{messages}");
+            }
+
+            Assert.IsTrue(results.All(r => r.Success),
+                "Test should pass - TriggersWhen should not trigger SF when response is 'success'");
+        }
+
+        /// <summary>
+        /// Test that TriggersWhen correctly triggers step function when response
+        /// indicates async work is pending (like CopyBlob returning "pending").
+        /// </summary>
+        [Test]
+        public async Task TriggersWhen_PendingResponse_StepFunctionTriggeredAndPolled()
+        {
+            var spec = new CopyOperationSpec();
+            var initialState = new CopyState { CopyStatus = "none" };
+
+            var inputSet = new InputSet()
+            {
+                new OperationInput("StartCopy", spec["StartCopy"]),
+                new OperationInput("UnrelatedCopy", spec["UnrelatedCopy"]),
+            };
+
+            var testCase = TestCaseGenerator.CreateManualSequentialTestCase(
+                spec.CreateTestingContext(),
+                inputSet,
+                "StartCopy", "UnrelatedCopy");
+
+            var context = spec.CreateTestingContext();
+
+            // Use CopyTarget with immediateSuccess=false - StartCopy returns "pending"
+            // TriggersWhen SHOULD trigger the step function, which will be polled
+            var results = await spec.RunTests(
+                context,
+                initialState,
+                new[] { testCase },
+                new TestExecutionOptions
+                {
+                    BeforeEach = _ => context.Register(new CopyTarget(immediateSuccess: false))
+                });
+
+            var failedResults = results.Where(r => !r.Success).ToList();
+            if (failedResults.Any())
+            {
+                var messages = string.Join("\n", failedResults.Select(r => r.LastFailureMessage));
+                Assert.Fail($"Test failed with messages:\n{messages}");
+            }
+
+            Assert.IsTrue(results.All(r => r.Success),
+                "Test should pass - TriggersWhen should trigger SF when response is 'pending', and polling should complete");
+        }
     }
 }

--- a/nuget/Microsoft.Accordant.Cli.nuspec
+++ b/nuget/Microsoft.Accordant.Cli.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Microsoft.Accordant.Cli</id>
-    <version>0.1.1-preview</version>
+    <version>0.1.2-preview</version>
     <authors>Microsoft</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>

--- a/nuget/Microsoft.Accordant.nuspec
+++ b/nuget/Microsoft.Accordant.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Microsoft.Accordant</id>
-    <version>0.1.1-preview</version>
+    <version>0.1.2-preview</version>
     <authors>Microsoft</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>


### PR DESCRIPTION
… operations

Bug: When a TerminatingStepFunction reached its terminal state during polling, it remained in the state profile. Subsequent operations would then incorrectly attempt to poll using that operation's (nonexistent) polling setup, causing a PollingException.

Fix: GetStepFunctionsToPollFor now filters out step functions that have already reached their terminal state by checking IsTerminalState(state) for each step function before including it in the result.

Added test case to verify the fix:
- TerminalStepFunction_ShouldNotTriggerPollingOnSubsequentOperations

The test creates a scenario where:
1. TriggerAsync triggers a step function with polling configured
2. Polling runs and the step function becomes terminal
3. NoPolling operation runs (no polling configured)
4. Previously this would fail; now it correctly passes