### PR TITLE
Generalize ConcurrentTestCase to segment-based model

### DIFF
--- a/Accordant.Operations/GenerationAlgorithms/ConcurrentTestCaseAlgorithms.cs
+++ b/Accordant.Operations/GenerationAlgorithms/ConcurrentTestCaseAlgorithms.cs
@@ -52,10 +52,13 @@ namespace Microsoft.Accordant
                             .Select(call => new TestCaseSegment(call))
                             .ToList();
 
+                        var clonedOperationCall = operationCall.Clone();
+                        clonedOperationCall.Name = operationCall.Name + " (2)";
+
                         var concurrentOperationCalls = new List<OperationCall>()
                         {
                             operationCall,
-                            operationCall
+                            clonedOperationCall
                         };
 
                         var segments = new List<TestCaseSegment>(sequentialSegments)

--- a/Accordant.Operations/GenerationAlgorithms/ConcurrentTestCaseAlgorithms.cs
+++ b/Accordant.Operations/GenerationAlgorithms/ConcurrentTestCaseAlgorithms.cs
@@ -48,21 +48,26 @@ namespace Microsoft.Accordant
                     {
                         var operationCall = (OperationCall)edge.Metadata;
 
-                        var sequentialOperationCalls = sequentialPrefix.ToList();
+                        var sequentialSegments = sequentialPrefix
+                            .Select(call => new TestCaseSegment(call))
+                            .ToList();
+
                         var concurrentOperationCalls = new List<OperationCall>()
                         {
                             operationCall,
                             operationCall
                         };
 
+                        var segments = new List<TestCaseSegment>(sequentialSegments)
+                        {
+                            new TestCaseSegment(concurrentOperationCalls)
+                        };
+
                         // Performing the same operation concurrently
                         testCases.Add(new ConcurrentTestCase()
                         {
-                            Description = TestCaseGenerator.ConstructDescriptionForConcurrentTestCase(
-                                sequentialOperationCalls,
-                                concurrentOperationCalls),
-                            SequentialOperationCalls = sequentialOperationCalls,
-                            ConcurrentOperationCalls = concurrentOperationCalls
+                            Description = TestCaseGenerator.ConstructDescriptionForConcurrentTestCase(segments),
+                            Segments = segments
                         });
                     }
 
@@ -75,14 +80,20 @@ namespace Microsoft.Accordant
                         {
                             var concurrentOperationList = edgeList.Select(e => (OperationCall)e.Metadata).ToList();
 
+                            var sequentialSegments = sequentialPrefix
+                                .Select(call => new TestCaseSegment(call))
+                                .ToList();
+
+                            var segments = new List<TestCaseSegment>(sequentialSegments)
+                            {
+                                new TestCaseSegment(concurrentOperationList)
+                            };
+
                             // Performing all the operations from the current node concurrently
                             testCases.Add(new ConcurrentTestCase()
                             {
-                                Description = TestCaseGenerator.ConstructDescriptionForConcurrentTestCase(
-                                    sequentialPrefix,
-                                    concurrentOperationList),
-                                SequentialOperationCalls = sequentialPrefix,
-                                ConcurrentOperationCalls = concurrentOperationList
+                                Description = TestCaseGenerator.ConstructDescriptionForConcurrentTestCase(segments),
+                                Segments = segments
                             });
                         }
                     }
@@ -98,14 +109,20 @@ namespace Microsoft.Accordant
                             {
                                 var concurrentOperationList = subset.Select(e => (OperationCall)e.Metadata).ToList();
 
+                                var sequentialSegments = sequentialPrefix
+                                    .Select(call => new TestCaseSegment(call))
+                                    .ToList();
+
+                                var segments = new List<TestCaseSegment>(sequentialSegments)
+                                {
+                                    new TestCaseSegment(concurrentOperationList)
+                                };
+
                                 // Performing subset of operations from the current node concurrently
                                 testCases.Add(new ConcurrentTestCase()
                                 {
-                                    Description = TestCaseGenerator.ConstructDescriptionForConcurrentTestCase(
-                                        sequentialPrefix,
-                                        concurrentOperationList),
-                                    SequentialOperationCalls = sequentialPrefix,
-                                    ConcurrentOperationCalls = concurrentOperationList
+                                    Description = TestCaseGenerator.ConstructDescriptionForConcurrentTestCase(segments),
+                                    Segments = segments
                                 });
                             }
                         }

--- a/Accordant.Operations/Persistence/ConcurrentTestCaseFileRecord.cs
+++ b/Accordant.Operations/Persistence/ConcurrentTestCaseFileRecord.cs
@@ -11,13 +11,8 @@ namespace Microsoft.Accordant
     public class ConcurrentTestCaseFileRecord : TestCaseFileRecord
     {
         /// <summary>
-        /// List of sequential operation calls that are executed before the concurrent calls.
+        /// The segments of this concurrent test case when serialized.
         /// </summary>
-        public IList<OperationCallFileRecord> SequentialOperationCalls { get; set; }
-
-        /// <summary>
-        /// List of concurrent operation calls executed after the sequential operation calls.
-        /// </summary>
-        public IList<OperationCallFileRecord> ConcurrentOperationCalls { get; set; }
+        public IList<TestCaseSegmentFileRecord> Segments { get; set; }
     }
 }

--- a/Accordant.Operations/Persistence/Conversions.cs
+++ b/Accordant.Operations/Persistence/Conversions.cs
@@ -56,35 +56,31 @@ namespace Microsoft.Accordant
             this ConcurrentTestCaseFileRecord testCaseFileRecord,
             ISpec spec)
         {
-            var sequentialOperationCalls = new List<OperationCall>();
-            var previousSequentialOperationCalls = new Dictionary<string, OperationCall>();
+            var segments = new List<TestCaseSegment>();
+            var previousOperationCalls = new Dictionary<string, OperationCall>();
 
-            foreach (var callFileRecord in testCaseFileRecord.SequentialOperationCalls)
+            foreach (var segmentFileRecord in testCaseFileRecord.Segments)
             {
-                var operationCall = callFileRecord.ToOperationCall(
-                    spec,
-                    previousSequentialOperationCalls);
+                var operationCalls = new List<OperationCall>();
 
-                sequentialOperationCalls.Add(operationCall);
-                previousSequentialOperationCalls[operationCall.Name] = operationCall;
-            }
+                foreach (var callFileRecord in segmentFileRecord.OperationCalls)
+                {
+                    var operationCall = callFileRecord.ToOperationCall(
+                        spec,
+                        previousOperationCalls);
 
-            var concurrentOperationCalls = new List<OperationCall>();
-            foreach (var callFileRecord in testCaseFileRecord.ConcurrentOperationCalls)
-            {
-                var operationCall = callFileRecord.ToOperationCall(
-                    spec,
-                    previousSequentialOperationCalls);
+                    operationCalls.Add(operationCall);
+                    previousOperationCalls[operationCall.Name] = operationCall;
+                }
 
-                concurrentOperationCalls.Add(operationCall);
+                segments.Add(new TestCaseSegment(operationCalls));
             }
 
             return new ConcurrentTestCase()
             {
                 Description = testCaseFileRecord.Description,
                 Comments = testCaseFileRecord.Comments,
-                SequentialOperationCalls = sequentialOperationCalls,
-                ConcurrentOperationCalls = concurrentOperationCalls
+                Segments = segments
             };
         }
 
@@ -96,12 +92,12 @@ namespace Microsoft.Accordant
             {
                 Description = testCase.Description,
                 Comments = testCase.Comments,
-                SequentialOperationCalls = testCase
-                    .SequentialOperationCalls
-                    .Select(call => call.ToOperationCallFileRecord(spec)).ToList(),
-                ConcurrentOperationCalls = testCase
-                    .ConcurrentOperationCalls
-                    .Select(call => call.ToOperationCallFileRecord(spec)).ToList()
+                Segments = testCase.Segments
+                    .Select(segment => new TestCaseSegmentFileRecord()
+                    {
+                        OperationCalls = segment.OperationCalls
+                            .Select(call => call.ToOperationCallFileRecord(spec)).ToList()
+                    }).ToList()
             };
         }
 

--- a/Accordant.Operations/Persistence/TestCaseSegmentFileRecord.cs
+++ b/Accordant.Operations/Persistence/TestCaseSegmentFileRecord.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Accordant
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// This class represents the file layout of <see cref="TestCaseSegment"/> when serialized.
+    /// </summary>
+    public class TestCaseSegmentFileRecord
+    {
+        /// <summary>
+        /// The operation calls in this segment.
+        /// </summary>
+        public IList<OperationCallFileRecord> OperationCalls { get; set; }
+    }
+}

--- a/Accordant.Operations/TestCase/ConcurrentTestCase.cs
+++ b/Accordant.Operations/TestCase/ConcurrentTestCase.cs
@@ -7,8 +7,11 @@ namespace Microsoft.Accordant
 
     public class ConcurrentTestCase : TestCase
     {
-        public IList<OperationCall> SequentialOperationCalls { get; set; }
-
-        public IList<OperationCall> ConcurrentOperationCalls { get; set; }
+        /// <summary>
+        /// The segments of this concurrent test case. Each segment contains one or more
+        /// operation calls. Segments with a single call are executed sequentially;
+        /// segments with multiple calls are executed concurrently.
+        /// </summary>
+        public IList<TestCaseSegment> Segments { get; set; }
     }
 }

--- a/Accordant.Operations/TestCase/TestCaseSegment.cs
+++ b/Accordant.Operations/TestCase/TestCaseSegment.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Accordant
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Represents a segment within a concurrent test case. A segment contains
+    /// one or more operation calls. If the segment contains a single operation
+    /// call, it is executed sequentially. If it contains multiple operation calls,
+    /// they are executed concurrently.
+    /// </summary>
+    public class TestCaseSegment
+    {
+        /// <summary>
+        /// The operation calls in this segment. A single call means sequential
+        /// execution; multiple calls means concurrent execution.
+        /// </summary>
+        public IList<OperationCall> OperationCalls { get; set; }
+
+        /// <summary>
+        /// Creates a new segment with the given operation calls.
+        /// </summary>
+        public TestCaseSegment(IList<OperationCall> operationCalls)
+        {
+            OperationCalls = operationCalls;
+        }
+
+        /// <summary>
+        /// Creates a new segment with a single operation call (sequential).
+        /// </summary>
+        public TestCaseSegment(OperationCall operationCall)
+        {
+            OperationCalls = new List<OperationCall> { operationCall };
+        }
+
+        /// <summary>
+        /// Returns true if this segment has a single operation call (sequential execution).
+        /// </summary>
+        public bool IsSequential => OperationCalls.Count == 1;
+
+        /// <summary>
+        /// Returns true if this segment has multiple operation calls (concurrent execution).
+        /// </summary>
+        public bool IsConcurrent => OperationCalls.Count > 1;
+    }
+}

--- a/Accordant.Operations/TestCaseExecutor.cs
+++ b/Accordant.Operations/TestCaseExecutor.cs
@@ -451,7 +451,23 @@ namespace Microsoft.Accordant
             Dictionary<string, object> operationCallResponses,
             TestExecutionOptions options)
         {
-            var stateProfile = new StateProfile(startingState);
+            return await ExecuteSequentialTestCaseInternal(
+                context,
+                new StateProfile(startingState),
+                operationCalls,
+                operationCallRequests,
+                operationCallResponses,
+                options);
+        }
+
+        private static async Task<(StateProfile, bool, string)> ExecuteSequentialTestCaseInternal(
+            TestingContext context,
+            StateProfile stateProfile,
+            IList<OperationCall> operationCalls,
+            Dictionary<string, object> operationCallRequests,
+            Dictionary<string, object> operationCallResponses,
+            TestExecutionOptions options)
+        {
 
             var numExecutions = new Dictionary<OperationCall, int>();
 
@@ -576,66 +592,63 @@ namespace Microsoft.Accordant
             ConcurrentTestCase testCase,
             TestExecutionOptions options)
         {
-            Logger.Log($"Executing {testCase.SequentialOperationCalls.Count} sequential operations");
-
             var operationCallRequests = new Dictionary<string, object>();
             var operationCallResponses = new Dictionary<string, object>();
+            var stateProfile = new StateProfile(startingState);
 
-            StateProfile stateProfileAfterSequentialOperations;
-            using (new Logger(indent: true))
+            for (int segmentIndex = 0; segmentIndex < testCase.Segments.Count; segmentIndex++)
             {
-                (stateProfileAfterSequentialOperations, var success, var failureMessage) = await ExecuteSequentialPartOfConcurrentTestInternal(
-                    context,
-                    testCase,
-                    startingState,
-                    operationCallRequests,
-                    operationCallResponses,
-                    options);
+                var segment = testCase.Segments[segmentIndex];
 
-                if (!success)
+                if (segment.IsSequential)
                 {
-                    return (null, false, failureMessage);
+                    Logger.Log($"Executing sequential segment {segmentIndex + 1} of {testCase.Segments.Count}");
+
+                    using (new Logger(indent: true))
+                    {
+                        var (newStateProfile, success, failureMessage) = await ExecuteSequentialTestCaseInternal(
+                            context,
+                            stateProfile,
+                            segment.OperationCalls,
+                            operationCallRequests,
+                            operationCallResponses,
+                            options);
+
+                        if (!success)
+                        {
+                            return (null, false, failureMessage);
+                        }
+
+                        stateProfile = newStateProfile;
+                    }
+                }
+                else
+                {
+                    Logger.Log(string.Empty);
+                    Logger.Log($"Executing concurrent segment {segmentIndex + 1} of {testCase.Segments.Count} ({segment.OperationCalls.Count} concurrent operations)");
+                    Logger.Log(string.Empty);
+
+                    using (new Logger(indent: true))
+                    {
+                        var (newStateProfile, success, failureMessage) = await ExecuteConcurrentOperationsInternal(
+                            context,
+                            segment.OperationCalls,
+                            stateProfile,
+                            operationCallRequests,
+                            operationCallResponses,
+                            options);
+
+                        if (!success)
+                        {
+                            return (null, false, failureMessage);
+                        }
+
+                        stateProfile = newStateProfile;
+                    }
                 }
             }
 
-            Logger.Log(string.Empty);
-            Logger.Log($"Executing {testCase.ConcurrentOperationCalls.Count} concurrent operations");
-            Logger.Log(string.Empty);
-
-            using (new Logger(indent: true))
-            {
-                var (stateProfile, success, failureMessage) = await ExecuteConcurrentOperationsInternal(
-                    context,
-                    testCase.ConcurrentOperationCalls,
-                    stateProfileAfterSequentialOperations,
-                    operationCallRequests,
-                    operationCallResponses,
-                    options);
-
-                return (stateProfile, success, failureMessage);
-            }
-        }
-
-        private static async Task<(StateProfile, bool, string)> ExecuteSequentialPartOfConcurrentTestInternal(
-            TestingContext context,
-            ConcurrentTestCase testCase,
-            IState startingState,
-            Dictionary<string, object> operationCallRequests,
-            Dictionary<string, object> operationCallResponses,
-            TestExecutionOptions options)
-        {
-            var (stateProfileAfterSequentialOperations, success, failureMessage) = await ExecuteSequentialTestCaseInternal(
-                context,
-                startingState,
-                testCase.SequentialOperationCalls,
-                operationCallRequests,
-                operationCallResponses,
-                options);
-
-            return (
-                stateProfileAfterSequentialOperations,
-                success,
-                failureMessage);
+            return (stateProfile, true, string.Empty);
         }
 
         private static async Task<(StateProfile, bool, string)> ExecuteConcurrentOperationsInternal(

--- a/Accordant.Operations/TestCaseExecutor.cs
+++ b/Accordant.Operations/TestCaseExecutor.cs
@@ -480,6 +480,7 @@ namespace Microsoft.Accordant
         {
 
             var numExecutions = new Dictionary<OperationCall, int>();
+            var stepFunctionsBefore = GetStepFunctionsToPollFor(stateProfile);
 
             for (int i = 0; i < operationCalls.Count; i++)
             {
@@ -567,13 +568,14 @@ namespace Microsoft.Accordant
 
                 stateProfile = newStateProfile;
 
-                // Check if any step functions require polling (are TerminatingStepFunction)
-                // and this input hasn't disabled polling
+                // Check if this operation introduced new step functions that require polling.
+                // Only poll for newly introduced ones (not pre-existing from earlier ops that skipped polling).
                 if (!operationCall.OperationInput.SkipPolling)
                 {
-                    var stepFunctionsToPollFor = GetStepFunctionsToPollFor(stateProfile);
+                    var stepFunctionsAfter = GetStepFunctionsToPollFor(stateProfile);
+                    stepFunctionsAfter.ExceptWith(stepFunctionsBefore);
 
-                    if (stepFunctionsToPollFor.Count > 0)
+                    if (stepFunctionsAfter.Count > 0)
                     {
                         var pollingSetup = FetchPollingSetup(operationCall);
                         var pollingOperation = FetchPollingOperation(context, operationCall, request, response);
@@ -583,7 +585,7 @@ namespace Microsoft.Accordant
                             stateProfile,
                             pollingOperation,
                             pollingSetup,
-                            stepFunctionsToPollFor);
+                            stepFunctionsAfter);
 
                         if (!success)
                         {
@@ -591,6 +593,9 @@ namespace Microsoft.Accordant
                         }
                     }
                 }
+
+                // Update snapshot for next iteration
+                stepFunctionsBefore = GetStepFunctionsToPollFor(stateProfile);
             }
 
             return (stateProfile, true, string.Empty);

--- a/Accordant.Operations/TestCaseExecutor.cs
+++ b/Accordant.Operations/TestCaseExecutor.cs
@@ -32,6 +32,11 @@ namespace Microsoft.Accordant
             if (initialState == null) throw new ArgumentNullException(nameof(initialState));
             options ??= new TestExecutionOptions();
 
+            foreach (var testCase in testCases)
+            {
+                ValidateSequentialTestCase(testCase);
+            }
+
             var spec = context.Spec;
             var runStartTime = DateTime.UtcNow;
 
@@ -177,6 +182,11 @@ namespace Microsoft.Accordant
             if (context == null) throw new ArgumentNullException(nameof(context));
             if (initialState == null) throw new ArgumentNullException(nameof(initialState));
             options ??= new TestExecutionOptions();
+
+            foreach (var testCase in testCases)
+            {
+                ValidateConcurrentTestCase(testCase);
+            }
 
             var spec = context.Spec;
             var runStartTime = DateTime.UtcNow;
@@ -592,8 +602,6 @@ namespace Microsoft.Accordant
             ConcurrentTestCase testCase,
             TestExecutionOptions options)
         {
-            ValidateConcurrentTestCase(testCase);
-
             var operationCallRequests = new Dictionary<string, object>();
             var operationCallResponses = new Dictionary<string, object>();
             var stateProfile = new StateProfile(startingState);
@@ -907,6 +915,32 @@ namespace Microsoft.Accordant
             }
 
             return (stateProfile, true, string.Empty);
+        }
+
+        /// <summary>
+        /// Validates a sequential test case before execution. Checks:
+        /// - Must have at least one operation call
+        /// - No duplicate operation call names
+        /// </summary>
+        private static void ValidateSequentialTestCase(SequentialTestCase testCase)
+        {
+            if (testCase.OperationCalls == null || testCase.OperationCalls.Count == 0)
+            {
+                throw new ArgumentException(
+                    $"Sequential test case '{testCase.Description}' has no operation calls. " +
+                    $"Each test case must have at least one operation call.");
+            }
+
+            var allNames = new HashSet<string>();
+            foreach (var operationCall in testCase.OperationCalls)
+            {
+                if (!allNames.Add(operationCall.Name))
+                {
+                    throw new ArgumentException(
+                        $"Duplicate operation call name '{operationCall.Name}' found in sequential test case '{testCase.Description}'. " +
+                        $"Operation call names must be unique.");
+                }
+            }
         }
 
         /// <summary>

--- a/Accordant.Operations/TestCaseExecutor.cs
+++ b/Accordant.Operations/TestCaseExecutor.cs
@@ -592,6 +592,8 @@ namespace Microsoft.Accordant
             ConcurrentTestCase testCase,
             TestExecutionOptions options)
         {
+            ValidateConcurrentTestCase(testCase);
+
             var operationCallRequests = new Dictionary<string, object>();
             var operationCallResponses = new Dictionary<string, object>();
             var stateProfile = new StateProfile(startingState);
@@ -624,6 +626,9 @@ namespace Microsoft.Accordant
                 }
                 else
                 {
+                    // Capture step functions before the concurrent segment for diffing
+                    var stepFunctionsBefore = GetStepFunctionsToPollFor(stateProfile);
+
                     Logger.Log(string.Empty);
                     Logger.Log($"Executing concurrent segment {segmentIndex + 1} of {testCase.Segments.Count} ({segment.OperationCalls.Count} concurrent operations)");
                     Logger.Log(string.Empty);
@@ -644,6 +649,30 @@ namespace Microsoft.Accordant
                         }
 
                         stateProfile = newStateProfile;
+
+                        // Poll for any newly introduced terminating step functions
+                        var stepFunctionsAfter = GetStepFunctionsToPollFor(stateProfile);
+                        var newStepFunctions = new HashSet<TerminatingStepFunction>(
+                            stepFunctionsAfter.Where(sf => !stepFunctionsBefore.Contains(sf)));
+
+                        if (newStepFunctions.Count > 0)
+                        {
+                            Logger.Log(string.Empty);
+                            Logger.Log($"Found {newStepFunctions.Count} new terminating step function(s) after concurrent segment. Polling...");
+
+                            (stateProfile, success, failureMessage) = await PollAfterConcurrentSegment(
+                                context,
+                                stateProfile,
+                                segment.OperationCalls,
+                                newStepFunctions,
+                                operationCallRequests,
+                                operationCallResponses);
+
+                            if (!success)
+                            {
+                                return (null, false, failureMessage);
+                            }
+                        }
                     }
                 }
             }
@@ -878,6 +907,171 @@ namespace Microsoft.Accordant
             }
 
             return (stateProfile, true, string.Empty);
+        }
+
+        /// <summary>
+        /// Validates a concurrent test case before execution. Checks:
+        /// - No empty segments
+        /// - No duplicate operation call names across all segments
+        /// - No same-segment derived request dependencies in concurrent segments
+        /// </summary>
+        private static void ValidateConcurrentTestCase(ConcurrentTestCase testCase)
+        {
+            var allOperationCallNames = new HashSet<string>();
+
+            for (int segmentIndex = 0; segmentIndex < testCase.Segments.Count; segmentIndex++)
+            {
+                var segment = testCase.Segments[segmentIndex];
+
+                if (segment.OperationCalls == null || segment.OperationCalls.Count == 0)
+                {
+                    throw new ArgumentException(
+                        $"Segment {segmentIndex + 1} has no operation calls. Each segment must have at least one operation call.");
+                }
+
+                foreach (var operationCall in segment.OperationCalls)
+                {
+                    if (!allOperationCallNames.Add(operationCall.Name))
+                    {
+                        throw new ArgumentException(
+                            $"Duplicate operation call name '{operationCall.Name}' found in test case '{testCase.Description}'. " +
+                            $"Operation call names must be unique across all segments.");
+                    }
+                }
+
+                // For concurrent segments, check that no operation derives from another in the same segment
+                if (segment.IsConcurrent)
+                {
+                    var segmentOperationCallNames = new HashSet<string>(
+                        segment.OperationCalls.Select(c => c.Name));
+
+                    foreach (var operationCall in segment.OperationCalls)
+                    {
+                        var derivedFrom = operationCall.OperationInput?.DerivedFromOperationCalls;
+                        if (derivedFrom != null)
+                        {
+                            foreach (var source in derivedFrom)
+                            {
+                                if (segmentOperationCallNames.Contains(source.Name))
+                                {
+                                    throw new ArgumentException(
+                                        $"Operation call '{operationCall.Name}' in concurrent segment {segmentIndex + 1} " +
+                                        $"derives from '{source.Name}' which is in the same segment. " +
+                                        $"Concurrent operations cannot derive from each other within the same segment.");
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Polls after a concurrent segment completes. Gathers polling operations from
+        /// all concurrent operation calls that have polling configured and SkipPolling is false,
+        /// then polls sequentially until all newly introduced terminating step functions
+        /// reach their terminal state.
+        /// </summary>
+        private static async Task<(StateProfile, bool, string)> PollAfterConcurrentSegment(
+            TestingContext context,
+            StateProfile stateProfile,
+            IList<OperationCall> concurrentOperationCalls,
+            HashSet<TerminatingStepFunction> stepFunctionsToPollFor,
+            Dictionary<string, object> operationCallRequests,
+            Dictionary<string, object> operationCallResponses)
+        {
+            // Gather polling operations from all concurrent ops that have polling configured
+            var pollingEntries = new List<(OperationInput pollingOperation, PollingSetup pollingSetup)>();
+
+            foreach (var operationCall in concurrentOperationCalls)
+            {
+                if (operationCall.OperationInput.SkipPolling)
+                {
+                    continue;
+                }
+
+                // Check if this operation has a polling setup
+                var pollingSetup = operationCall.OperationInput.Polling
+                                ?? operationCall.OperationInput.Operation.Polling;
+
+                if (pollingSetup == null)
+                {
+                    continue;
+                }
+
+                var request = operationCallRequests.ContainsKey(operationCall.Name)
+                    ? operationCallRequests[operationCall.Name]
+                    : operationCall.OperationInput.Request;
+                var response = operationCallResponses.ContainsKey(operationCall.Name)
+                    ? operationCallResponses[operationCall.Name]
+                    : null;
+
+                var pollingOperation = FetchPollingOperation(context, operationCall, request, response);
+                pollingEntries.Add((pollingOperation, pollingSetup));
+            }
+
+            if (pollingEntries.Count == 0)
+            {
+                Logger.Log("No polling operations configured for concurrent segment.");
+                return (stateProfile, true, string.Empty);
+            }
+
+            Logger.Log($"Polling with {pollingEntries.Count} polling operation(s) after concurrent segment.");
+
+            // Create a minimal options object for polling (no retry, no step executed hook)
+            var pollingOptions = new TestExecutionOptions();
+
+            // Track retry counts per polling entry
+            var retryCounts = new int[pollingEntries.Count];
+
+            while (true)
+            {
+                // Execute each polling operation sequentially
+                for (int i = 0; i < pollingEntries.Count; i++)
+                {
+                    var (pollingOperation, pollingSetup) = pollingEntries[i];
+
+                    retryCounts[i]++;
+
+                    if (retryCounts[i] > pollingSetup.MaxRetryCount)
+                    {
+                        var failureMessage =
+                            $"Gave up polling using {pollingOperation.Name} after retrying " +
+                            $"{pollingSetup.MaxRetryCount} times with a delay of {pollingSetup.WaitTimeInMs}ms " +
+                            $"between each retry. Some TerminatingStepFunctions did not reach their terminal state.";
+
+                        return (stateProfile, false, failureMessage);
+                    }
+
+                    Logger.Log($"Polling by calling {pollingOperation.Name}");
+
+                    using (new Logger(indent: true))
+                    {
+                        var (newStateProfile, valid, message, pollingResponse) = await ExecuteOperationCallAsync(
+                            context,
+                            stateProfile,
+                            pollingOperation.Name,
+                            pollingOperation.Operation,
+                            pollingOperation.Request,
+                            pollingOptions);
+
+                        stateProfile = newStateProfile;
+                    }
+                }
+
+                // Check if all specified TerminatingStepFunctions have reached their terminal state
+                if (AllTerminatingStepFunctionsComplete(stateProfile, stepFunctionsToPollFor))
+                {
+                    Logger.Log("All terminating step functions have completed after concurrent segment polling.");
+                    return (stateProfile, true, string.Empty);
+                }
+
+                // Wait using the maximum delay across all polling entries
+                var maxWaitTime = pollingEntries.Max(e => e.pollingSetup.WaitTimeInMs);
+                await Task.Delay(maxWaitTime);
+
+                LogPendingStepFunctions(stateProfile, stepFunctionsToPollFor);
+            }
         }
 
         /// <summary>

--- a/Accordant.Operations/TestCaseExecutor.cs
+++ b/Accordant.Operations/TestCaseExecutor.cs
@@ -951,6 +951,13 @@ namespace Microsoft.Accordant
         /// </summary>
         private static void ValidateConcurrentTestCase(ConcurrentTestCase testCase)
         {
+            if (testCase.Segments == null || testCase.Segments.Count == 0)
+            {
+                throw new ArgumentException(
+                    $"Concurrent test case '{testCase.Description}' has no segments. " +
+                    $"Each test case must have at least one segment.");
+            }
+
             var allOperationCallNames = new HashSet<string>();
 
             for (int segmentIndex = 0; segmentIndex < testCase.Segments.Count; segmentIndex++)
@@ -1055,26 +1062,29 @@ namespace Microsoft.Accordant
             // Create a minimal options object for polling (no retry, no step executed hook)
             var pollingOptions = new TestExecutionOptions();
 
-            // Track retry counts per polling entry
+            // Track retry counts per polling entry and which ones are exhausted
             var retryCounts = new int[pollingEntries.Count];
+            var exhausted = new bool[pollingEntries.Count];
 
             while (true)
             {
-                // Execute each polling operation sequentially
+                // Execute each non-exhausted polling operation sequentially
                 for (int i = 0; i < pollingEntries.Count; i++)
                 {
+                    if (exhausted[i])
+                    {
+                        continue;
+                    }
+
                     var (pollingOperation, pollingSetup) = pollingEntries[i];
 
                     retryCounts[i]++;
 
                     if (retryCounts[i] > pollingSetup.MaxRetryCount)
                     {
-                        var failureMessage =
-                            $"Gave up polling using {pollingOperation.Name} after retrying " +
-                            $"{pollingSetup.MaxRetryCount} times with a delay of {pollingSetup.WaitTimeInMs}ms " +
-                            $"between each retry. Some TerminatingStepFunctions did not reach their terminal state.";
-
-                        return (stateProfile, false, failureMessage);
+                        Logger.Log($"Polling operation {pollingOperation.Name} exhausted its retry count ({pollingSetup.MaxRetryCount}).");
+                        exhausted[i] = true;
+                        continue;
                     }
 
                     Logger.Log($"Polling by calling {pollingOperation.Name}");
@@ -1100,8 +1110,19 @@ namespace Microsoft.Accordant
                     return (stateProfile, true, string.Empty);
                 }
 
-                // Wait using the maximum delay across all polling entries
-                var maxWaitTime = pollingEntries.Max(e => e.pollingSetup.WaitTimeInMs);
+                // If all pollers are exhausted and step functions still pending, fail
+                if (exhausted.All(e => e))
+                {
+                    var failureMessage =
+                        $"Gave up polling after all polling operations exhausted their retry counts. " +
+                        $"Some TerminatingStepFunctions did not reach their terminal state.";
+
+                    return (stateProfile, false, failureMessage);
+                }
+
+                // Wait using the maximum delay across non-exhausted polling entries
+                var activeEntries = pollingEntries.Where((_, i) => !exhausted[i]).ToList();
+                var maxWaitTime = activeEntries.Max(e => e.pollingSetup.WaitTimeInMs);
                 await Task.Delay(maxWaitTime);
 
                 LogPendingStepFunctions(stateProfile, stepFunctionsToPollFor);

--- a/Accordant.Operations/TestCaseGenerator.cs
+++ b/Accordant.Operations/TestCaseGenerator.cs
@@ -92,9 +92,10 @@ namespace Microsoft.Accordant
                 context,
                 rootNode);
 
-            // Filter out empty test cases (those with no operations)
+            // Filter out empty test cases (those with no segments or all empty segments)
             testCases = testCases
-                .Where(tc => tc.SequentialOperationCalls.Count > 0 || tc.ConcurrentOperationCalls.Count > 0)
+                .Where(tc => tc.Segments != null && tc.Segments.Count > 0 &&
+                    tc.Segments.Any(s => s.OperationCalls.Count > 0))
                 .ToList();
 
             return testCases;
@@ -236,13 +237,22 @@ namespace Microsoft.Accordant
                     concurrentOperationNames,
                     baseIndex: sequentialPrefixOperationNames.Count);
 
+            var segments = new List<TestCaseSegment>();
+
+            foreach (var call in sequentialOperationCalls)
+            {
+                segments.Add(new TestCaseSegment(call));
+            }
+
+            if (concurrentOperationCalls.Count > 0)
+            {
+                segments.Add(new TestCaseSegment(concurrentOperationCalls));
+            }
+
             var testCase = new ConcurrentTestCase()
             {
-                Description = ConstructDescriptionForConcurrentTestCase(
-                    sequentialOperationCalls,
-                    concurrentOperationCalls),
-                SequentialOperationCalls = sequentialOperationCalls,
-                ConcurrentOperationCalls = concurrentOperationCalls
+                Description = ConstructDescriptionForConcurrentTestCase(segments),
+                Segments = segments
             };
 
             return testCase;
@@ -337,20 +347,23 @@ namespace Microsoft.Accordant
         }
 
         public static string ConstructDescriptionForConcurrentTestCase(
-            IList<OperationCall> sequentialCallPrefix,
-            IList<OperationCall> concurrentCalls)
+            IList<TestCaseSegment> segments)
         {
-            var sequentialPart = string.Join("; ", sequentialCallPrefix.Select(c => c.Name));
-            var concurrentPart = string.Join(" || ", concurrentCalls.Select(c => c.Name));
+            var parts = new List<string>();
 
-            if (sequentialPart.Length > 0)
+            foreach (var segment in segments)
             {
-                return sequentialPart + " --> " + concurrentPart;
+                if (segment.IsSequential)
+                {
+                    parts.Add(segment.OperationCalls[0].Name);
+                }
+                else
+                {
+                    parts.Add(string.Join(" || ", segment.OperationCalls.Select(c => c.Name)));
+                }
             }
-            else
-            {
-                return concurrentPart;
-            }
+
+            return string.Join(" --> ", parts);
         }
 
         public static string SerializeSequentialTestCases(

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     
     <!-- NuGet Package Defaults -->
-    <Version>0.1.4</Version>
+    <Version>0.1.5</Version>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
     <Copyright>Copyright (c) 2024-2026 Microsoft Corporation</Copyright>

--- a/Scripts/create-nuget-packages.ps1
+++ b/Scripts/create-nuget-packages.ps1
@@ -1,0 +1,37 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Import-Module $PSScriptRoot/common.psm1 -Force
+
+$nuget = "nuget"
+
+# Check that NuGet.exe is installed.
+if (-not (Get-Command $nuget -errorAction SilentlyContinue)) {
+    Write-Comment -text "Please install the latest NuGet.exe from https://www.nuget.org/downloads and add it to the PATH environment variable." -color "yellow"
+    exit 1
+}
+
+Write-Comment -prefix "." -text "Creating the Accordant NuGet packages" -color "yellow"
+
+$version = "0.1.5"
+
+# Setup the command line options for nuget pack.
+$cmd_options = "-OutputDirectory $PSScriptRoot/../bin/packages -Version $version"
+$cmd_options = "$cmd_options -Symbols -SymbolPackageFormat snupkg"
+
+Write-Comment -prefix "..." -text "Creating the 'Microsoft.Accordant' package"
+
+$command = "pack $PSScriptRoot/../nuget/Microsoft.Accordant.nuspec $cmd_options"
+$error_msg = "Failed to create the Microsoft.Accordant NuGet package"
+Invoke-ToolCommand -tool $nuget -cmd $command -error_msg $error_msg
+
+# Tool packages don't need symbols
+$tool_cmd_options = "-OutputDirectory $PSScriptRoot/../bin/packages -Version $version"
+
+Write-Comment -prefix "..." -text "Creating the 'Microsoft.Accordant.Cli' package (dotnet tool)"
+
+$command = "pack $PSScriptRoot/../nuget/Microsoft.Accordant.Cli.nuspec $tool_cmd_options"
+$error_msg = "Failed to create the Microsoft.Accordant.Cli NuGet package"
+Invoke-ToolCommand -tool $nuget -cmd $command -error_msg $error_msg
+
+Write-Comment -prefix "." -text "Successfully created the Accordant NuGet packages" -color "green"

--- a/Tests/Accordant.Operations.Tests/SampleClasses.cs
+++ b/Tests/Accordant.Operations.Tests/SampleClasses.cs
@@ -749,4 +749,209 @@ namespace Microsoft.Accordant.Operations.Tests
     }
 
     #endregion
+
+    #region DualAsync Spec - Two Independent Async Operations
+
+    /// <summary>
+    /// State for two independent async jobs (A and B).
+    /// </summary>
+    [State]
+    public partial class DualAsyncState : State
+    {
+        public string JobAStatus { get; set; } = "none";
+        public string JobBStatus { get; set; } = "none";
+    }
+
+    /// <summary>
+    /// Spec with two independent async operations (StartJobA, StartJobB),
+    /// each with its own polling operation (PollJobA, PollJobB).
+    /// Designed to test concurrent polling after a concurrent segment.
+    /// </summary>
+    public class DualAsyncSpec : Spec<DualAsyncState>
+    {
+        public StartJobAOperation StartJobA { get; } = new();
+        public PollJobAOperation PollJobA { get; } = new();
+        public StartJobBOperation StartJobB { get; } = new();
+        public PollJobBOperation PollJobB { get; } = new();
+
+        public DualAsyncSpec()
+        {
+            this["StartJobA"] = StartJobA;
+            this["PollJobA"] = PollJobA;
+            this["StartJobB"] = StartJobB;
+            this["PollJobB"] = PollJobB;
+        }
+    }
+
+    public class JobAStepFunction : TerminatingStepFunction
+    {
+        public override Func<IState, bool> IsTerminalState => state =>
+        {
+            var s = (DualAsyncState)state;
+            return s.JobAStatus != "pending";
+        };
+
+        protected override IList<StepResult> GetStepResults(IState state)
+        {
+            var next = (DualAsyncState)state.Clone();
+            next.JobAStatus = "done";
+            return new[] { new StepResult { State = next } };
+        }
+    }
+
+    public class JobBStepFunction : TerminatingStepFunction
+    {
+        public override Func<IState, bool> IsTerminalState => state =>
+        {
+            var s = (DualAsyncState)state;
+            return s.JobBStatus != "pending";
+        };
+
+        protected override IList<StepResult> GetStepResults(IState state)
+        {
+            var next = (DualAsyncState)state.Clone();
+            next.JobBStatus = "done";
+            return new[] { new StepResult { State = next } };
+        }
+    }
+
+    public class StartJobAOperation : Operation<Unit, string, DualAsyncState>
+    {
+        public StartJobAOperation() : base("StartJobA") { }
+
+        public override PollingSetup Polling => new PollingSetup
+        {
+            Operation = "PollJobA",
+            WaitTimeInMs = 10,
+            MaxRetryCount = 100
+        };
+
+        public override ExpectedOutcomes Apply(Unit request, DualAsyncState state)
+        {
+            if (state.JobAStatus != "none")
+                return Expect.That(r => r == "already started", "already started").SameState();
+
+            return Expect.That(r => r == "pending", "job A started")
+                         .WithNextState(new DualAsyncState { JobAStatus = "pending", JobBStatus = state.JobBStatus })
+                         .Triggers(new JobAStepFunction());
+        }
+
+        public override string Execute(TestingContext context, Unit request)
+        {
+            return context.Get<DualAsyncTarget>().StartJobA();
+        }
+    }
+
+    public class PollJobAOperation : Operation<Unit, string, DualAsyncState>
+    {
+        public PollJobAOperation() : base("PollJobA") { }
+
+        public override IReadOnlyList<RequestDerivation> DerivedFrom => new[]
+        {
+            Derive.From<Unit, string, Unit>("StartJobA")
+                  .As((req, resp) => Unit.Value)
+        };
+
+        public override ExpectedOutcomes Apply(Unit request, DualAsyncState state)
+        {
+            return Expect.That(r => r == state.JobAStatus, $"should return '{state.JobAStatus}'")
+                         .SameState();
+        }
+
+        public override string Execute(TestingContext context, Unit request)
+        {
+            return context.Get<DualAsyncTarget>().GetJobAStatus();
+        }
+    }
+
+    public class StartJobBOperation : Operation<Unit, string, DualAsyncState>
+    {
+        public StartJobBOperation() : base("StartJobB") { }
+
+        public override PollingSetup Polling => new PollingSetup
+        {
+            Operation = "PollJobB",
+            WaitTimeInMs = 10,
+            MaxRetryCount = 100
+        };
+
+        public override ExpectedOutcomes Apply(Unit request, DualAsyncState state)
+        {
+            if (state.JobBStatus != "none")
+                return Expect.That(r => r == "already started", "already started").SameState();
+
+            return Expect.That(r => r == "pending", "job B started")
+                         .WithNextState(new DualAsyncState { JobAStatus = state.JobAStatus, JobBStatus = "pending" })
+                         .Triggers(new JobBStepFunction());
+        }
+
+        public override string Execute(TestingContext context, Unit request)
+        {
+            return context.Get<DualAsyncTarget>().StartJobB();
+        }
+    }
+
+    public class PollJobBOperation : Operation<Unit, string, DualAsyncState>
+    {
+        public PollJobBOperation() : base("PollJobB") { }
+
+        public override IReadOnlyList<RequestDerivation> DerivedFrom => new[]
+        {
+            Derive.From<Unit, string, Unit>("StartJobB")
+                  .As((req, resp) => Unit.Value)
+        };
+
+        public override ExpectedOutcomes Apply(Unit request, DualAsyncState state)
+        {
+            return Expect.That(r => r == state.JobBStatus, $"should return '{state.JobBStatus}'")
+                         .SameState();
+        }
+
+        public override string Execute(TestingContext context, Unit request)
+        {
+            return context.Get<DualAsyncTarget>().GetJobBStatus();
+        }
+    }
+
+    /// <summary>
+    /// Target with two independent async jobs.
+    /// </summary>
+    public class DualAsyncTarget
+    {
+        private string jobAStatus = "none";
+        private string jobBStatus = "none";
+
+        public string StartJobA()
+        {
+            if (jobAStatus == "none")
+            {
+                jobAStatus = "pending";
+                _ = Task.Run(async () =>
+                {
+                    await Task.Delay(5);
+                    jobAStatus = "done";
+                });
+            }
+            return jobAStatus;
+        }
+
+        public string StartJobB()
+        {
+            if (jobBStatus == "none")
+            {
+                jobBStatus = "pending";
+                _ = Task.Run(async () =>
+                {
+                    await Task.Delay(5);
+                    jobBStatus = "done";
+                });
+            }
+            return jobBStatus;
+        }
+
+        public string GetJobAStatus() => jobAStatus;
+        public string GetJobBStatus() => jobBStatus;
+    }
+
+    #endregion
 }

--- a/Tests/Accordant.Operations.Tests/SerializationTests.cs
+++ b/Tests/Accordant.Operations.Tests/SerializationTests.cs
@@ -120,13 +120,29 @@ namespace Microsoft.Accordant.Operations.Tests
                 tc1.Description == tc2.Description &&
                 tc1.Comments == tc2.Comments &&
                 AreListsSame(
-                    tc1.SequentialOperationCalls,
-                    tc2.SequentialOperationCalls,
-                    AreOperationCallsSame) &&
-                AreListsSame(
-                    tc1.ConcurrentOperationCalls,
-                    tc2.ConcurrentOperationCalls,
-                    AreOperationCallsSame);
+                    tc1.Segments,
+                    tc2.Segments,
+                    AreSegmentsSame);
+        }
+
+        private static bool AreSegmentsSame(
+            TestCaseSegment s1,
+            TestCaseSegment s2)
+        {
+            if (s1 == null)
+            {
+                return s2 == null;
+            }
+
+            if (s2 == null)
+            {
+                return s1 == null;
+            }
+
+            return AreListsSame(
+                s1.OperationCalls,
+                s2.OperationCalls,
+                AreOperationCallsSame);
         }
 
         private static bool AreSequentialTestCaseSame(

--- a/Tests/Accordant.Operations.Tests/TestExecutorTests.cs
+++ b/Tests/Accordant.Operations.Tests/TestExecutorTests.cs
@@ -1537,6 +1537,32 @@ namespace Microsoft.Accordant.Operations.Tests
         #region Validation Tests
 
         [Test]
+        public void ConcurrentTestCase_NullSegmentsThrows()
+        {
+            var spec = new SimpleStatefulClassSpec();
+            var initialState = new CounterState(0);
+
+            var testCase = new ConcurrentTestCase()
+            {
+                Description = "null segments test",
+                Segments = null
+            };
+
+            var context = spec.CreateTestingContext();
+            context.Register(new SimpleStatefulClass());
+
+            var ex = Assert.ThrowsAsync<ArgumentException>(async () =>
+                await spec.RunTests(
+                    context,
+                    initialState,
+                    new[] { testCase },
+                    new TestExecutionOptions()));
+
+            Assert.IsTrue(ex.Message.Contains("no segments"),
+                $"Expected 'no segments' in message, got: {ex.Message}");
+        }
+
+        [Test]
         public void ConcurrentTestCase_EmptySegmentThrows()
         {
             var spec = new SimpleStatefulClassSpec();
@@ -1695,6 +1721,32 @@ namespace Microsoft.Accordant.Operations.Tests
             {
                 Description = "empty ops test",
                 OperationCalls = new List<OperationCall>()
+            };
+
+            var context = spec.CreateTestingContext();
+            context.Register(new SimpleStatefulClass());
+
+            var ex = Assert.ThrowsAsync<ArgumentException>(async () =>
+                await spec.RunTests(
+                    context,
+                    initialState,
+                    new[] { testCase },
+                    new TestExecutionOptions()));
+
+            Assert.IsTrue(ex.Message.Contains("no operation calls"),
+                $"Expected 'no operation calls' in message, got: {ex.Message}");
+        }
+
+        [Test]
+        public void SequentialTestCase_NullOperationCallsThrows()
+        {
+            var spec = new SimpleStatefulClassSpec();
+            var initialState = new CounterState(0);
+
+            var testCase = new SequentialTestCase()
+            {
+                Description = "null ops test",
+                OperationCalls = null
             };
 
             var context = spec.CreateTestingContext();

--- a/Tests/Accordant.Operations.Tests/TestExecutorTests.cs
+++ b/Tests/Accordant.Operations.Tests/TestExecutorTests.cs
@@ -513,7 +513,7 @@ namespace Microsoft.Accordant.Operations.Tests
                 });
 
             int uniqueOperationCalls = concurrentTestCases.Sum(
-                tc => tc.SequentialOperationCalls.Count + (tc.ConcurrentOperationCalls.Count > 0 ? 1 : 0));
+                tc => tc.Segments.Count);
 
             int stepExecutedHookCalledTimes = 0;
             int beforeEachCalledTimes = 0;
@@ -1206,5 +1206,332 @@ namespace Microsoft.Accordant.Operations.Tests
             Assert.IsTrue(results.All(r => r.Success),
                 "Test should pass - TriggersWhen should trigger SF when response is 'pending', and polling should complete");
         }
+
+        #region Segment-based ConcurrentTestCase Tests
+
+        [Test]
+        public async Task ConcurrentTestCase_GeneratedTestCasesHaveSegments()
+        {
+            var spec = new SimpleStatefulClassSpec();
+            var initialState = new CounterState(0);
+
+            var inputSet = new InputSet()
+            {
+                new OperationInput("Add 2", spec["Add"], 2),
+                new OperationInput("Count", spec["Count"])
+            };
+
+            var concurrentTestCases = spec.GenerateConcurrentTests(
+                initialState,
+                inputSet,
+                new TestGenerationOptions { MaxDepth = 3 });
+
+            Assert.IsTrue(concurrentTestCases.Count > 0, "Should generate concurrent test cases");
+
+            foreach (var testCase in concurrentTestCases)
+            {
+                Assert.IsNotNull(testCase.Segments, "Segments should not be null");
+                Assert.IsTrue(testCase.Segments.Count > 0, "Should have at least one segment");
+
+                foreach (var segment in testCase.Segments)
+                {
+                    Assert.IsNotNull(segment.OperationCalls, "Segment OperationCalls should not be null");
+                    Assert.IsTrue(segment.OperationCalls.Count > 0, "Each segment should have at least one operation call");
+                }
+
+                // Last segment should be concurrent (multiple ops)
+                var lastSegment = testCase.Segments[testCase.Segments.Count - 1];
+                Assert.IsTrue(lastSegment.IsConcurrent, "Last segment should be concurrent");
+
+                // All non-last segments should be sequential (single op)
+                for (int i = 0; i < testCase.Segments.Count - 1; i++)
+                {
+                    Assert.IsTrue(testCase.Segments[i].IsSequential,
+                        $"Segment {i} should be sequential (single op)");
+                }
+            }
+        }
+
+        [Test]
+        public async Task ConcurrentTestCase_ManualMultiSegmentTestCase()
+        {
+            // Create a multi-segment test case manually:
+            // Segment 1 (seq): Add 2
+            // Segment 2 (concurrent): Add 2 || Count
+            // Segment 3 (seq): Count
+            var spec = new SimpleStatefulClassSpec();
+            var initialState = new CounterState(0);
+
+            var inputSet = new InputSet()
+            {
+                new OperationInput("Add 2", spec["Add"], 2),
+                new OperationInput("Count", spec["Count"])
+            };
+
+            var segments = new List<TestCaseSegment>
+            {
+                new TestCaseSegment(new OperationCall("Add 2", inputSet["Add 2"])),
+                new TestCaseSegment(new List<OperationCall>
+                {
+                    new OperationCall("Add 2 concurrent", inputSet["Add 2"]),
+                    new OperationCall("Count concurrent", inputSet["Count"])
+                }),
+                new TestCaseSegment(new OperationCall("Count final", inputSet["Count"]))
+            };
+
+            var testCase = new ConcurrentTestCase()
+            {
+                Description = TestCaseGenerator.ConstructDescriptionForConcurrentTestCase(segments),
+                Segments = segments
+            };
+
+            Assert.IsTrue(testCase.Segments[0].IsSequential);
+            Assert.IsTrue(testCase.Segments[1].IsConcurrent);
+            Assert.IsTrue(testCase.Segments[2].IsSequential);
+
+            var context = spec.CreateTestingContext();
+            var results = await spec.RunTests(
+                context,
+                initialState,
+                new[] { testCase },
+                new TestExecutionOptions
+                {
+                    BeforeEach = _ => context.Register(new SimpleStatefulClass())
+                });
+
+            Assert.IsTrue(results.All(r => r.Success),
+                "Multi-segment concurrent test case should pass");
+        }
+
+        [Test]
+        public async Task ConcurrentTestCase_ConcurrentOnlySegment()
+        {
+            // Test case with no sequential prefix — just a concurrent segment
+            var spec = new SimpleStatefulClassSpec();
+            var initialState = new CounterState(0);
+
+            var inputSet = new InputSet()
+            {
+                new OperationInput("Add 2", spec["Add"], 2),
+                new OperationInput("Count", spec["Count"])
+            };
+
+            var segments = new List<TestCaseSegment>
+            {
+                new TestCaseSegment(new List<OperationCall>
+                {
+                    new OperationCall("Add 2", inputSet["Add 2"]),
+                    new OperationCall("Count", inputSet["Count"])
+                })
+            };
+
+            var testCase = new ConcurrentTestCase()
+            {
+                Description = TestCaseGenerator.ConstructDescriptionForConcurrentTestCase(segments),
+                Segments = segments
+            };
+
+            var context = spec.CreateTestingContext();
+            var results = await spec.RunTests(
+                context,
+                initialState,
+                new[] { testCase },
+                new TestExecutionOptions
+                {
+                    BeforeEach = _ => context.Register(new SimpleStatefulClass())
+                });
+
+            Assert.IsTrue(results.All(r => r.Success),
+                "Concurrent-only test case should pass");
+        }
+
+        [Test]
+        public void ConcurrentTestCase_DescriptionFormatting()
+        {
+            var call1 = new OperationCall("A", null);
+            var call2 = new OperationCall("B", null);
+            var call3 = new OperationCall("C", null);
+
+            // Sequential only
+            var segments1 = new List<TestCaseSegment>
+            {
+                new TestCaseSegment(call1),
+                new TestCaseSegment(call2)
+            };
+            var desc1 = TestCaseGenerator.ConstructDescriptionForConcurrentTestCase(segments1);
+            Assert.AreEqual("A --> B", desc1);
+
+            // Concurrent only
+            var segments2 = new List<TestCaseSegment>
+            {
+                new TestCaseSegment(new List<OperationCall> { call1, call2 })
+            };
+            var desc2 = TestCaseGenerator.ConstructDescriptionForConcurrentTestCase(segments2);
+            Assert.AreEqual("A || B", desc2);
+
+            // Mixed: seq -> concurrent -> seq
+            var segments3 = new List<TestCaseSegment>
+            {
+                new TestCaseSegment(call1),
+                new TestCaseSegment(new List<OperationCall> { call2, call3 }),
+                new TestCaseSegment(call1)
+            };
+            var desc3 = TestCaseGenerator.ConstructDescriptionForConcurrentTestCase(segments3);
+            Assert.AreEqual("A --> B || C --> A", desc3);
+        }
+
+        [Test]
+        public async Task ConcurrentTestCase_OnStepExecutedHookCalledPerSegment()
+        {
+            var spec = new SimpleStatefulClassSpec();
+            var initialState = new CounterState(0);
+
+            var inputSet = new InputSet()
+            {
+                new OperationInput("Add 2", spec["Add"], 2),
+                new OperationInput("Count", spec["Count"])
+            };
+
+            // Create a test case with 3 segments: seq, concurrent, seq
+            var segments = new List<TestCaseSegment>
+            {
+                new TestCaseSegment(new OperationCall("Add 2", inputSet["Add 2"])),
+                new TestCaseSegment(new List<OperationCall>
+                {
+                    new OperationCall("Add 2 again", inputSet["Add 2"]),
+                    new OperationCall("Count concurrent", inputSet["Count"])
+                }),
+                new TestCaseSegment(new OperationCall("Count final", inputSet["Count"]))
+            };
+
+            var testCase = new ConcurrentTestCase()
+            {
+                Description = TestCaseGenerator.ConstructDescriptionForConcurrentTestCase(segments),
+                Segments = segments
+            };
+
+            int stepExecutedCount = 0;
+            int singleOpCount = 0;
+            int multiOpCount = 0;
+
+            var context = spec.CreateTestingContext();
+            var results = await spec.RunTests(
+                context,
+                initialState,
+                new[] { testCase },
+                new TestExecutionOptions
+                {
+                    BeforeEach = _ => context.Register(new SimpleStatefulClass()),
+                    OnStepExecuted = (ctx) =>
+                    {
+                        stepExecutedCount++;
+                        if (ctx.IsSingleOperation) singleOpCount++;
+                        else multiOpCount++;
+                    }
+                });
+
+            Assert.IsTrue(results.All(r => r.Success));
+            Assert.AreEqual(3, stepExecutedCount, "OnStepExecuted should be called once per segment");
+            Assert.AreEqual(2, singleOpCount, "Two sequential segments should trigger single-op hooks");
+            Assert.AreEqual(1, multiOpCount, "One concurrent segment should trigger multi-op hook");
+        }
+
+        [Test]
+        public async Task ConcurrentTestCase_BuggyBehaviorDetected()
+        {
+            // Verify that a multi-segment test case can detect buggy behavior
+            var spec = new SimpleStatefulClassSpec();
+            var initialState = new CounterState(0);
+
+            var inputSet = new InputSet()
+            {
+                new OperationInput("Add 2", spec["Add"], 2),
+                new OperationInput("Count", spec["Count"])
+            };
+
+            var segments = new List<TestCaseSegment>
+            {
+                new TestCaseSegment(new OperationCall("Add 2", inputSet["Add 2"])),
+                new TestCaseSegment(new OperationCall("Count", inputSet["Count"]))
+            };
+
+            var testCase = new ConcurrentTestCase()
+            {
+                Description = TestCaseGenerator.ConstructDescriptionForConcurrentTestCase(segments),
+                Segments = segments
+            };
+
+            // Should fail with buggy behavior
+            var context = spec.CreateTestingContext();
+            var results = await spec.RunTests(
+                context,
+                initialState,
+                new[] { testCase },
+                new TestExecutionOptions
+                {
+                    BeforeEach = _ => context.Register(new SimpleStatefulClass(simulateBuggyBehavior: true))
+                });
+
+            Assert.IsTrue(results.Any(r => !r.Success),
+                "Multi-segment test should detect buggy behavior");
+        }
+
+        [Test]
+        public void ConcurrentTestCase_SegmentProperties()
+        {
+            var call1 = new OperationCall("A", null);
+            var call2 = new OperationCall("B", null);
+
+            var seqSegment = new TestCaseSegment(call1);
+            Assert.IsTrue(seqSegment.IsSequential);
+            Assert.IsFalse(seqSegment.IsConcurrent);
+            Assert.AreEqual(1, seqSegment.OperationCalls.Count);
+
+            var concSegment = new TestCaseSegment(new List<OperationCall> { call1, call2 });
+            Assert.IsFalse(concSegment.IsSequential);
+            Assert.IsTrue(concSegment.IsConcurrent);
+            Assert.AreEqual(2, concSegment.OperationCalls.Count);
+        }
+
+        [Test]
+        public void ConcurrentTestCase_SerializationRoundTrip()
+        {
+            var spec = new SimpleStatefulClassSpec();
+
+            var inputSet = new InputSet()
+            {
+                new OperationInput("Add 2", spec["Add"], 2),
+                new OperationInput("Count", spec["Count"])
+            };
+
+            var initialState = new CounterState(0);
+
+            var concurrentTestCases = spec.GenerateConcurrentTests(
+                initialState,
+                inputSet,
+                new TestGenerationOptions { MaxDepth = 3 });
+
+            var context = spec.CreateTestingContext();
+
+            var serialized = TestCaseGenerator.SerializeConcurrentTestCases(context, concurrentTestCases);
+            var deserialized = TestCaseGenerator.DeserializeConcurrentTestCases(context, serialized);
+
+            Assert.AreEqual(concurrentTestCases.Count, deserialized.Count);
+
+            for (int i = 0; i < concurrentTestCases.Count; i++)
+            {
+                Assert.AreEqual(concurrentTestCases[i].Description, deserialized[i].Description);
+                Assert.AreEqual(concurrentTestCases[i].Segments.Count, deserialized[i].Segments.Count);
+
+                for (int j = 0; j < concurrentTestCases[i].Segments.Count; j++)
+                {
+                    Assert.AreEqual(
+                        concurrentTestCases[i].Segments[j].OperationCalls.Count,
+                        deserialized[i].Segments[j].OperationCalls.Count);
+                }
+            }
+        }
+
+        #endregion
     }
 }

--- a/Tests/Accordant.Operations.Tests/TestExecutorTests.cs
+++ b/Tests/Accordant.Operations.Tests/TestExecutorTests.cs
@@ -1537,7 +1537,7 @@ namespace Microsoft.Accordant.Operations.Tests
         #region Validation Tests
 
         [Test]
-        public async Task ConcurrentTestCase_EmptySegmentThrows()
+        public void ConcurrentTestCase_EmptySegmentThrows()
         {
             var spec = new SimpleStatefulClassSpec();
             var initialState = new CounterState(0);
@@ -1556,19 +1556,19 @@ namespace Microsoft.Accordant.Operations.Tests
             var context = spec.CreateTestingContext();
             context.Register(new SimpleStatefulClass());
 
-            var results = await spec.RunTests(
-                context,
-                initialState,
-                new[] { testCase },
-                new TestExecutionOptions());
+            var ex = Assert.ThrowsAsync<ArgumentException>(async () =>
+                await spec.RunTests(
+                    context,
+                    initialState,
+                    new[] { testCase },
+                    new TestExecutionOptions()));
 
-            Assert.IsFalse(results[0].Success, "Test should fail for empty segment");
-            Assert.IsTrue(results[0].LastFailureMessage.Contains("no operation calls"),
-                $"Expected 'no operation calls' in message, got: {results[0].LastFailureMessage}");
+            Assert.IsTrue(ex.Message.Contains("no operation calls"),
+                $"Expected 'no operation calls' in message, got: {ex.Message}");
         }
 
         [Test]
-        public async Task ConcurrentTestCase_DuplicateOpNameAcrossSegmentsThrows()
+        public void ConcurrentTestCase_DuplicateOpNameAcrossSegmentsThrows()
         {
             var spec = new SimpleStatefulClassSpec();
             var initialState = new CounterState(0);
@@ -1595,19 +1595,19 @@ namespace Microsoft.Accordant.Operations.Tests
             var context = spec.CreateTestingContext();
             context.Register(new SimpleStatefulClass());
 
-            var results = await spec.RunTests(
-                context,
-                initialState,
-                new[] { testCase },
-                new TestExecutionOptions());
+            var ex = Assert.ThrowsAsync<ArgumentException>(async () =>
+                await spec.RunTests(
+                    context,
+                    initialState,
+                    new[] { testCase },
+                    new TestExecutionOptions()));
 
-            Assert.IsFalse(results[0].Success, "Test should fail for duplicate names");
-            Assert.IsTrue(results[0].LastFailureMessage.Contains("Duplicate operation call name"),
-                $"Expected 'Duplicate operation call name' in message, got: {results[0].LastFailureMessage}");
+            Assert.IsTrue(ex.Message.Contains("Duplicate operation call name"),
+                $"Expected 'Duplicate operation call name' in message, got: {ex.Message}");
         }
 
         [Test]
-        public async Task ConcurrentTestCase_SameSegmentDerivedRequestThrows()
+        public void ConcurrentTestCase_SameSegmentDerivedRequestThrows()
         {
             var spec = new SimpleStatefulClassSpec();
             var initialState = new CounterState(0);
@@ -1642,15 +1642,15 @@ namespace Microsoft.Accordant.Operations.Tests
             var context = spec.CreateTestingContext();
             context.Register(new SimpleStatefulClass());
 
-            var results = await spec.RunTests(
-                context,
-                initialState,
-                new[] { testCase },
-                new TestExecutionOptions());
+            var ex = Assert.ThrowsAsync<ArgumentException>(async () =>
+                await spec.RunTests(
+                    context,
+                    initialState,
+                    new[] { testCase },
+                    new TestExecutionOptions()));
 
-            Assert.IsFalse(results[0].Success, "Test should fail for same-segment derived request");
-            Assert.IsTrue(results[0].LastFailureMessage.Contains("same segment"),
-                $"Expected 'same segment' in message, got: {results[0].LastFailureMessage}");
+            Assert.IsTrue(ex.Message.Contains("same segment"),
+                $"Expected 'same segment' in message, got: {ex.Message}");
         }
 
         [Test]
@@ -1683,6 +1683,68 @@ namespace Microsoft.Accordant.Operations.Tests
                     $"Test case '{testCase.Description}' has duplicate operation call names: " +
                     $"{string.Join(", ", allNames)}");
             }
+        }
+
+        [Test]
+        public void SequentialTestCase_EmptyOperationCallsThrows()
+        {
+            var spec = new SimpleStatefulClassSpec();
+            var initialState = new CounterState(0);
+
+            var testCase = new SequentialTestCase()
+            {
+                Description = "empty ops test",
+                OperationCalls = new List<OperationCall>()
+            };
+
+            var context = spec.CreateTestingContext();
+            context.Register(new SimpleStatefulClass());
+
+            var ex = Assert.ThrowsAsync<ArgumentException>(async () =>
+                await spec.RunTests(
+                    context,
+                    initialState,
+                    new[] { testCase },
+                    new TestExecutionOptions()));
+
+            Assert.IsTrue(ex.Message.Contains("no operation calls"),
+                $"Expected 'no operation calls' in message, got: {ex.Message}");
+        }
+
+        [Test]
+        public void SequentialTestCase_DuplicateOpNameThrows()
+        {
+            var spec = new SimpleStatefulClassSpec();
+            var initialState = new CounterState(0);
+
+            var inputSet = new InputSet()
+            {
+                new OperationInput("Add 2", spec["Add"], 2),
+                new OperationInput("Count", spec["Count"])
+            };
+
+            var testCase = new SequentialTestCase()
+            {
+                Description = "duplicate name test",
+                OperationCalls = new List<OperationCall>
+                {
+                    new OperationCall("Add 2", inputSet["Add 2"]),
+                    new OperationCall("Add 2", inputSet["Add 2"])
+                }
+            };
+
+            var context = spec.CreateTestingContext();
+            context.Register(new SimpleStatefulClass());
+
+            var ex = Assert.ThrowsAsync<ArgumentException>(async () =>
+                await spec.RunTests(
+                    context,
+                    initialState,
+                    new[] { testCase },
+                    new TestExecutionOptions()));
+
+            Assert.IsTrue(ex.Message.Contains("Duplicate operation call name"),
+                $"Expected 'Duplicate operation call name' in message, got: {ex.Message}");
         }
 
         #endregion
@@ -1817,6 +1879,154 @@ namespace Microsoft.Accordant.Operations.Tests
 
             Assert.IsTrue(results.All(r => r.Success),
                 "Multi-segment test with polling should pass");
+        }
+
+        [Test]
+        public async Task ConcurrentTestCase_DualPollingAfterConcurrentSegment()
+        {
+            // Two independent async ops (StartJobA, StartJobB) in a concurrent segment.
+            // Both have polling configured. Polling should complete both jobs.
+            var spec = new DualAsyncSpec();
+            var initialState = new DualAsyncState();
+
+            var inputSet = new InputSet()
+            {
+                new OperationInput("StartJobA", spec["StartJobA"]),
+                new OperationInput("StartJobB", spec["StartJobB"])
+            };
+
+            var segments = new List<TestCaseSegment>
+            {
+                new TestCaseSegment(new List<OperationCall>
+                {
+                    new OperationCall("StartJobA", inputSet["StartJobA"]),
+                    new OperationCall("StartJobB", inputSet["StartJobB"])
+                })
+            };
+
+            var testCase = new ConcurrentTestCase()
+            {
+                Description = TestCaseGenerator.ConstructDescriptionForConcurrentTestCase(segments),
+                Segments = segments
+            };
+
+            var context = spec.CreateTestingContext();
+            context.Register(new DualAsyncTarget());
+
+            var results = await spec.RunTests(
+                context,
+                initialState,
+                new[] { testCase },
+                new TestExecutionOptions());
+
+            Assert.IsTrue(results.All(r => r.Success),
+                "Dual concurrent polling should complete both jobs. " +
+                $"Failure: {results.FirstOrDefault(r => !r.Success)?.LastFailureMessage}");
+        }
+
+        [Test]
+        public async Task ConcurrentTestCase_PollingFailureExhaustsRetryCount()
+        {
+            // Use DualAsyncTarget but set MaxRetryCount=0 so polling immediately fails.
+            var spec = new DualAsyncSpec();
+            var initialState = new DualAsyncState();
+
+            var startAInput = new OperationInput("StartJobA", spec["StartJobA"]);
+            startAInput.WithPolling(new PollingSetup
+            {
+                Operation = "PollJobA",
+                WaitTimeInMs = 1,
+                MaxRetryCount = 0
+            });
+
+            var startBInput = new OperationInput("StartJobB", spec["StartJobB"]);
+            startBInput.WithPolling(new PollingSetup
+            {
+                Operation = "PollJobB",
+                WaitTimeInMs = 1,
+                MaxRetryCount = 0
+            });
+
+            var inputSet = new InputSet() { startAInput, startBInput };
+
+            // Must be concurrent segment to test PollAfterConcurrentSegment
+            var segments = new List<TestCaseSegment>
+            {
+                new TestCaseSegment(new List<OperationCall>
+                {
+                    new OperationCall("StartJobA", inputSet["StartJobA"]),
+                    new OperationCall("StartJobB", inputSet["StartJobB"])
+                })
+            };
+
+            var testCase = new ConcurrentTestCase()
+            {
+                Description = "polling failure test",
+                Segments = segments
+            };
+
+            var context = spec.CreateTestingContext();
+            context.Register(new DualAsyncTarget());
+
+            var results = await spec.RunTests(
+                context,
+                initialState,
+                new[] { testCase },
+                new TestExecutionOptions());
+
+            Assert.IsFalse(results[0].Success, "Test should fail when polling exhausts retries");
+            Assert.IsTrue(results[0].LastFailureMessage.Contains("Gave up polling"),
+                $"Expected 'Gave up polling' in message, got: {results[0].LastFailureMessage}");
+        }
+
+        [Test]
+        public async Task ConcurrentTestCase_PreExistingStepFunctionsNotPolledAgain()
+        {
+            // Segment 1 (sequential): StartJobA — triggers step function A, polling completes it
+            // Segment 2 (concurrent): StartJobB || PollJobA (as a no-op observation)
+            // After segment 2, only JobB's step function should need polling (A already done)
+            var spec = new DualAsyncSpec();
+            var initialState = new DualAsyncState();
+
+            var inputSet = new InputSet()
+            {
+                new OperationInput("StartJobA", spec["StartJobA"]),
+                new OperationInput("StartJobB", spec["StartJobB"]),
+                new OperationInput("PollJobA", spec["PollJobA"])
+            };
+
+            var startJobACall = new OperationCall("StartJobA", inputSet["StartJobA"]);
+
+            var segments = new List<TestCaseSegment>
+            {
+                // Segment 1: sequential StartJobA (polling will complete it)
+                new TestCaseSegment(startJobACall),
+                // Segment 2: concurrent StartJobB + PollJobA observation
+                new TestCaseSegment(new List<OperationCall>
+                {
+                    new OperationCall("StartJobB", inputSet["StartJobB"]),
+                    new OperationCall("PollJobA", inputSet["PollJobA"])
+                })
+            };
+
+            var testCase = new ConcurrentTestCase()
+            {
+                Description = TestCaseGenerator.ConstructDescriptionForConcurrentTestCase(segments),
+                Segments = segments
+            };
+
+            var context = spec.CreateTestingContext();
+            context.Register(new DualAsyncTarget());
+
+            var results = await spec.RunTests(
+                context,
+                initialState,
+                new[] { testCase },
+                new TestExecutionOptions());
+
+            Assert.IsTrue(results.All(r => r.Success),
+                "Pre-existing step functions from segment 1 should not interfere with segment 2 polling. " +
+                $"Failure: {results.FirstOrDefault(r => !r.Success)?.LastFailureMessage}");
         }
 
         #endregion

--- a/Tests/Accordant.Operations.Tests/TestExecutorTests.cs
+++ b/Tests/Accordant.Operations.Tests/TestExecutorTests.cs
@@ -1533,5 +1533,292 @@ namespace Microsoft.Accordant.Operations.Tests
         }
 
         #endregion
+
+        #region Validation Tests
+
+        [Test]
+        public async Task ConcurrentTestCase_EmptySegmentThrows()
+        {
+            var spec = new SimpleStatefulClassSpec();
+            var initialState = new CounterState(0);
+
+            var segments = new List<TestCaseSegment>
+            {
+                new TestCaseSegment(new List<OperationCall>()) // empty!
+            };
+
+            var testCase = new ConcurrentTestCase()
+            {
+                Description = "empty segment test",
+                Segments = segments
+            };
+
+            var context = spec.CreateTestingContext();
+            context.Register(new SimpleStatefulClass());
+
+            var results = await spec.RunTests(
+                context,
+                initialState,
+                new[] { testCase },
+                new TestExecutionOptions());
+
+            Assert.IsFalse(results[0].Success, "Test should fail for empty segment");
+            Assert.IsTrue(results[0].LastFailureMessage.Contains("no operation calls"),
+                $"Expected 'no operation calls' in message, got: {results[0].LastFailureMessage}");
+        }
+
+        [Test]
+        public async Task ConcurrentTestCase_DuplicateOpNameAcrossSegmentsThrows()
+        {
+            var spec = new SimpleStatefulClassSpec();
+            var initialState = new CounterState(0);
+
+            var inputSet = new InputSet()
+            {
+                new OperationInput("Add 2", spec["Add"], 2),
+                new OperationInput("Count", spec["Count"])
+            };
+
+            // Same name "Add 2" in two different segments
+            var segments = new List<TestCaseSegment>
+            {
+                new TestCaseSegment(new OperationCall("Add 2", inputSet["Add 2"])),
+                new TestCaseSegment(new OperationCall("Add 2", inputSet["Add 2"]))
+            };
+
+            var testCase = new ConcurrentTestCase()
+            {
+                Description = "duplicate name test",
+                Segments = segments
+            };
+
+            var context = spec.CreateTestingContext();
+            context.Register(new SimpleStatefulClass());
+
+            var results = await spec.RunTests(
+                context,
+                initialState,
+                new[] { testCase },
+                new TestExecutionOptions());
+
+            Assert.IsFalse(results[0].Success, "Test should fail for duplicate names");
+            Assert.IsTrue(results[0].LastFailureMessage.Contains("Duplicate operation call name"),
+                $"Expected 'Duplicate operation call name' in message, got: {results[0].LastFailureMessage}");
+        }
+
+        [Test]
+        public async Task ConcurrentTestCase_SameSegmentDerivedRequestThrows()
+        {
+            var spec = new SimpleStatefulClassSpec();
+            var initialState = new CounterState(0);
+
+            var inputSet = new InputSet()
+            {
+                new OperationInput("Add 2", spec["Add"], 2),
+                new OperationInput("Count", spec["Count"])
+            };
+
+            // Create an operation call that derives from another in the same concurrent segment
+            var sourceCall = new OperationCall("Source", inputSet["Add 2"]);
+            var derivedInput = new OperationInput(
+                "Derived",
+                spec["Count"],
+                Unit.Value,
+                new List<OperationCall> { sourceCall },
+                null);
+            var derivedCall = new OperationCall("Derived", derivedInput);
+
+            var segments = new List<TestCaseSegment>
+            {
+                new TestCaseSegment(new List<OperationCall> { sourceCall, derivedCall })
+            };
+
+            var testCase = new ConcurrentTestCase()
+            {
+                Description = "same-segment derived test",
+                Segments = segments
+            };
+
+            var context = spec.CreateTestingContext();
+            context.Register(new SimpleStatefulClass());
+
+            var results = await spec.RunTests(
+                context,
+                initialState,
+                new[] { testCase },
+                new TestExecutionOptions());
+
+            Assert.IsFalse(results[0].Success, "Test should fail for same-segment derived request");
+            Assert.IsTrue(results[0].LastFailureMessage.Contains("same segment"),
+                $"Expected 'same segment' in message, got: {results[0].LastFailureMessage}");
+        }
+
+        [Test]
+        public async Task ConcurrentTestCase_GeneratedTestCasesHaveUniqueNames()
+        {
+            var spec = new SimpleStatefulClassSpec();
+            var initialState = new CounterState(0);
+
+            var inputSet = new InputSet()
+            {
+                new OperationInput("Add 2", spec["Add"], 2),
+                new OperationInput("Count", spec["Count"])
+            };
+
+            var concurrentTestCases = spec.GenerateConcurrentTests(
+                initialState,
+                inputSet,
+                new TestGenerationOptions { MaxDepth = 3 });
+
+            // Verify that all generated test cases have unique names within each test case
+            foreach (var testCase in concurrentTestCases)
+            {
+                var allNames = testCase.Segments
+                    .SelectMany(s => s.OperationCalls)
+                    .Select(c => c.Name)
+                    .ToList();
+
+                var uniqueNames = new HashSet<string>(allNames);
+                Assert.AreEqual(allNames.Count, uniqueNames.Count,
+                    $"Test case '{testCase.Description}' has duplicate operation call names: " +
+                    $"{string.Join(", ", allNames)}");
+            }
+        }
+
+        #endregion
+
+        #region Concurrent Polling Tests
+
+        [Test]
+        public async Task ConcurrentTestCase_PollingAfterConcurrentSegment()
+        {
+            // Use the AsyncOperationSpec which has StartAsync (with polling) and Unrelated (no polling)
+            var spec = new AsyncOperationSpec();
+            var initialState = new AsyncOperationState();
+
+            var inputSet = new InputSet()
+            {
+                new OperationInput("StartAsync", spec["StartAsync"]),
+                new OperationInput("Unrelated", spec["Unrelated"])
+            };
+
+            // Create a concurrent segment with StartAsync + Unrelated
+            // StartAsync has polling configured — polling should run after the concurrent segment
+            var segments = new List<TestCaseSegment>
+            {
+                new TestCaseSegment(new List<OperationCall>
+                {
+                    new OperationCall("StartAsync", inputSet["StartAsync"]),
+                    new OperationCall("Unrelated", inputSet["Unrelated"])
+                })
+            };
+
+            var testCase = new ConcurrentTestCase()
+            {
+                Description = TestCaseGenerator.ConstructDescriptionForConcurrentTestCase(segments),
+                Segments = segments
+            };
+
+            var context = spec.CreateTestingContext();
+            context.Register(new AsyncWorkTarget());
+
+            var results = await spec.RunTests(
+                context,
+                initialState,
+                new[] { testCase },
+                new TestExecutionOptions());
+
+            Assert.IsTrue(results.All(r => r.Success),
+                "Concurrent test with polling should pass — polling should complete the async work. " +
+                $"Failure: {results.FirstOrDefault(r => !r.Success)?.LastFailureMessage}");
+        }
+
+        [Test]
+        public async Task ConcurrentTestCase_PollingSkippedWhenFlagSet()
+        {
+            // Verify SkipPolling is respected for concurrent segments
+            var spec = new AsyncOperationSpec();
+            var initialState = new AsyncOperationState();
+
+            var inputWithoutPolling = new OperationInput("StartAsync", spec["StartAsync"]);
+            inputWithoutPolling.WithoutPolling();
+
+            var inputSet = new InputSet()
+            {
+                inputWithoutPolling,
+                new OperationInput("Unrelated", spec["Unrelated"])
+            };
+
+            // Create test with concurrent segment where polling is skipped
+            var segments = new List<TestCaseSegment>
+            {
+                new TestCaseSegment(new List<OperationCall>
+                {
+                    new OperationCall("StartAsync", inputSet["StartAsync"]),
+                    new OperationCall("Unrelated", inputSet["Unrelated"])
+                })
+            };
+
+            var testCase = new ConcurrentTestCase()
+            {
+                Description = "skip polling test",
+                Segments = segments
+            };
+
+            var context = spec.CreateTestingContext();
+            context.Register(new AsyncWorkTarget());
+
+            // Should succeed — no polling means we accept the state as is
+            var results = await spec.RunTests(
+                context,
+                initialState,
+                new[] { testCase },
+                new TestExecutionOptions());
+
+            // The test should complete (not hang or throw polling-related errors)
+            Assert.IsTrue(results.Count == 1, "Should have exactly one result");
+        }
+
+        [Test]
+        public async Task ConcurrentTestCase_MultiSegmentWithPolling()
+        {
+            // seq(StartAsync) -> polling completes -> seq(GetStatus should show success)
+            var spec = new AsyncOperationSpec();
+            var initialState = new AsyncOperationState();
+
+            var inputSet = new InputSet()
+            {
+                new OperationInput("StartAsync", spec["StartAsync"]),
+                new OperationInput("Unrelated", spec["Unrelated"])
+            };
+
+            // Segment 1: Start async (sequential — polling happens after this)
+            // Segment 2: Unrelated (sequential — should work after polling completed)
+            var segments = new List<TestCaseSegment>
+            {
+                new TestCaseSegment(new OperationCall("StartAsync", inputSet["StartAsync"])),
+                new TestCaseSegment(new OperationCall("Unrelated", inputSet["Unrelated"]))
+            };
+
+            var testCase = new ConcurrentTestCase()
+            {
+                Description = TestCaseGenerator.ConstructDescriptionForConcurrentTestCase(segments),
+                Segments = segments
+            };
+
+            var context = spec.CreateTestingContext();
+            context.Register(new AsyncWorkTarget());
+
+            var results = await spec.RunTests(
+                context,
+                initialState,
+                new[] { testCase },
+                new TestExecutionOptions());
+
+            Assert.IsTrue(results.All(r => r.Success),
+                "Multi-segment test with polling should pass");
+        }
+
+        #endregion
     }
 }

--- a/Tests/Accordant.Operations.Tests/TestExecutorTests.cs
+++ b/Tests/Accordant.Operations.Tests/TestExecutorTests.cs
@@ -1534,6 +1534,55 @@ namespace Microsoft.Accordant.Operations.Tests
 
         #endregion
 
+        #region Sequential Polling - SkipPolling Step Function Leakage
+
+        [Test]
+        public async Task SequentialTestCase_SkipPollingDoesNotLeakStepFunctionsToNextOp()
+        {
+            // Op A (StartAsync) with SkipPolling=true triggers a step function.
+            // Op B (Unrelated) has no polling configured.
+            // With the bug: B sees A's non-terminal step function, tries to poll,
+            //   and crashes because B has no polling setup.
+            // With the fix: B only considers step functions introduced by itself (none),
+            //   so no polling is attempted and the test passes.
+            var spec = new AsyncOperationSpec();
+            var initialState = new AsyncOperationState();
+
+            var startInput = new OperationInput("StartAsync", spec["StartAsync"]);
+            startInput.WithoutPolling();
+
+            var inputSet = new InputSet()
+            {
+                startInput,
+                new OperationInput("Unrelated", spec["Unrelated"])
+            };
+
+            var testCase = new SequentialTestCase()
+            {
+                Description = "SkipPolling leakage test",
+                OperationCalls = new List<OperationCall>
+                {
+                    new OperationCall("StartAsync", inputSet["StartAsync"]),
+                    new OperationCall("Unrelated", inputSet["Unrelated"])
+                }
+            };
+
+            var context = spec.CreateTestingContext();
+            context.Register(new AsyncWorkTarget());
+
+            var results = await spec.RunTests(
+                context,
+                initialState,
+                new[] { testCase },
+                new TestExecutionOptions());
+
+            Assert.IsTrue(results.All(r => r.Success),
+                "Unrelated op should not be forced to poll for StartAsync's step function. " +
+                $"Failure: {results.FirstOrDefault(r => !r.Success)?.LastFailureMessage}");
+        }
+
+        #endregion
+
         #region Validation Tests
 
         [Test]

--- a/Tests/Accordant.Operations.Tests/TestExecutorTests.cs
+++ b/Tests/Accordant.Operations.Tests/TestExecutorTests.cs
@@ -1534,7 +1534,7 @@ namespace Microsoft.Accordant.Operations.Tests
 
         #endregion
 
-        #region Sequential Polling - SkipPolling Step Function Leakage
+        #region Polling - SkipPolling Step Function Leakage
 
         [Test]
         public async Task SequentialTestCase_SkipPollingDoesNotLeakStepFunctionsToNextOp()
@@ -1578,6 +1578,50 @@ namespace Microsoft.Accordant.Operations.Tests
 
             Assert.IsTrue(results.All(r => r.Success),
                 "Unrelated op should not be forced to poll for StartAsync's step function. " +
+                $"Failure: {results.FirstOrDefault(r => !r.Success)?.LastFailureMessage}");
+        }
+
+        [Test]
+        public async Task ConcurrentTestCase_SkipPollingDoesNotLeakToNextSegment()
+        {
+            // Segment 1 (sequential): StartJobA with SkipPolling=true — triggers step function A
+            // Segment 2 (concurrent): StartJobB (has polling) — triggers step function B
+            // After segment 2, polling should only target B's step function, not A's.
+            var spec = new DualAsyncSpec();
+            var initialState = new DualAsyncState();
+
+            var startAInput = new OperationInput("StartJobA", spec["StartJobA"]);
+            startAInput.WithoutPolling();
+
+            var inputSet = new InputSet()
+            {
+                startAInput,
+                new OperationInput("StartJobB", spec["StartJobB"])
+            };
+
+            var segments = new List<TestCaseSegment>
+            {
+                new TestCaseSegment(new OperationCall("StartJobA", inputSet["StartJobA"])),
+                new TestCaseSegment(new OperationCall("StartJobB", inputSet["StartJobB"]))
+            };
+
+            var testCase = new ConcurrentTestCase()
+            {
+                Description = TestCaseGenerator.ConstructDescriptionForConcurrentTestCase(segments),
+                Segments = segments
+            };
+
+            var context = spec.CreateTestingContext();
+            context.Register(new DualAsyncTarget());
+
+            var results = await spec.RunTests(
+                context,
+                initialState,
+                new[] { testCase },
+                new TestExecutionOptions());
+
+            Assert.IsTrue(results.All(r => r.Success),
+                "Segment 2 should only poll for its own step functions, not segment 1's skipped ones. " +
                 $"Failure: {results.FirstOrDefault(r => !r.Success)?.LastFailureMessage}");
         }
 

--- a/nuget/Microsoft.Accordant.Cli.nuspec
+++ b/nuget/Microsoft.Accordant.Cli.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Microsoft.Accordant.Cli</id>
-    <version>0.1.4</version>
+    <version>0.1.5</version>
     <authors>Microsoft</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>

--- a/nuget/Microsoft.Accordant.nuspec
+++ b/nuget/Microsoft.Accordant.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Microsoft.Accordant</id>
-    <version>0.1.4</version>
+    <version>0.1.5</version>
     <authors>Microsoft</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>


### PR DESCRIPTION
Replace the rigid two-phase structure (sequential prefix + concurrent batch) with a generic list of TestCaseSegment, where each segment is either sequential (1 op) or concurrent (N ops). This enables representing richer test shapes like seq -> concurrent -> seq -> concurrent.

Key changes:
- New TestCaseSegment class with IsSequential/IsConcurrent helpers
- ConcurrentTestCase now has IList<TestCaseSegment> Segments
- TestCaseExecutor loops over segments, dispatching each appropriately
- Added StateProfile overload for ExecuteSequentialTestCaseInternal
- Updated serialization, conversions, and test generation
- 8 new tests covering multi-segment execution, serialization, hooks