### PR TITLE
Fix docs build - exclude agent/ from docfx metadata

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -5,7 +5,7 @@
       "src": [
         {
           "files": ["**/*.csproj"],
-          "exclude": ["**/bin/**", "**/obj/**", "Tests/**", "Samples/**"],
+          "exclude": ["**/bin/**", "**/obj/**", "Tests/**", "Samples/**", "agent/**"],
           "src": "."
         }
       ],


### PR DESCRIPTION
The agent/starter/ExampleTests.csproj template has inline Version attributes that conflict with Central Package Management, breaking the docfx build. Excludes agent/** from the docfx project glob