### PR TITLE
Fix broken links in docs and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Executable behavioral specifications for .NET**
 
-[Documentation](https://microsoft.github.io/accordant) · [NuGet](https://nuget.org/packages/Microsoft.Accordant) · [Samples](Samples/)
+[Documentation](https://microsoft.github.io/accordant) · [NuGet](https://www.nuget.org/packages/Microsoft.Accordant) · [Samples](Samples/)
 
 Accordant is a framework for model-based testing. You write a *spec* — executable code that captures the rules of your system. Given any state and any operation, the spec defines what the response should be and how the state should change. Accordant then generates hundreds of tests from this spec, runs them against your real implementation, and validates every response — telling you exactly where the implementation deviates from the rules.
 
@@ -191,7 +191,7 @@ The same spec enables other kinds of testing:
 
 ## Get Started
 
-Install the package ([NuGet](https://nuget.org/packages/Microsoft.Accordant)):
+Install the package ([NuGet](https://www.nuget.org/packages/Microsoft.Accordant)):
 
 ```bash
 dotnet add package Microsoft.Accordant
@@ -235,7 +235,7 @@ Passed VisualizeStateSpace [20 ms]
 | **[Concepts](docs/concepts/index.md)** | Understand the theory — model-based testing, linearizability, state graphs |
 | **[How-To Guides](docs/how-to/index.md)** | Solve specific problems — "how do I reset state between tests?" |
 | **[Samples](Samples/)** | Working code — BankAccount, TodoList, and more |
-| **[API Reference](api/)** | Complete API documentation |
+| **[API Reference](https://microsoft.github.io/accordant/api/Microsoft.Accordant.html)** | Complete API documentation |
 
 ---
 

--- a/docs/concepts/what-is-model-based-testing.md
+++ b/docs/concepts/what-is-model-based-testing.md
@@ -267,7 +267,7 @@ Call `GetOrder(orderId)` and it returns the order? Now we know it was created �
 This ability to track uncertainty, then resolve it through observation, is what makes Accordant powerful for testing real distributed systems.
 
 **Other scenarios where multiple states arise:**
-- **Async background work** — a job is processing; has it finished yet? → [Step Functions & Async Behavior](step-functions-async.md)
+- **Async background work** — a job is processing; has it finished yet? → [Step Functions & Async Behavior](step-functions-and-async.md)
 - **Race conditions** — two concurrent requests compete; either could "win" → [Testing Race Conditions](../tutorials/05-testing-race-conditions.md)
 - **Server-generated values** — IDs and timestamps that you capture from responses → [Response-Dependent State](../tutorials/03-response-dependent-state.md)
 

--- a/docs/how-to/indefinite-failures.md
+++ b/docs/how-to/indefinite-failures.md
@@ -202,7 +202,7 @@ This is the power of state profiles: they track what's *possible*, and conforman
 
 ## See Also
 
-- [Step Functions & Async](step-functions-and-async.md)
+- [Step Functions & Async](../concepts/step-functions-and-async.md)
 - **Sample**: [TodoList-FaultInjection](https://github.com/microsoft/accordant/tree/main/Samples/TodoList-FaultInjection) — A complete working example demonstrating:
   - Server-side fault injection (pre/post save DB faults)
   - Client-side fault injection (network failures)

--- a/docs/index.md
+++ b/docs/index.md
@@ -189,7 +189,7 @@ The same spec enables other kinds of testing:
 
 ## Get Started
 
-Install the package ([NuGet](https://nuget.org/packages/Microsoft.Accordant)):
+Install the package ([NuGet](https://www.nuget.org/packages/Microsoft.Accordant)):
 
 ```bash
 dotnet add package Microsoft.Accordant

--- a/docs/tutorials/01-your-first-spec.md
+++ b/docs/tutorials/01-your-first-spec.md
@@ -395,7 +395,6 @@ You've learned the core Accordant workflow:
 
 - **[Tutorial 2: Handling Errors](02-handling-errors.md)** - Exception handling with `Expect.Throws<>`
 - **[Tutorial 3: Response-Dependent State](03-response-dependent-state.md)** - When the server returns values you need to track
-- **[Concept: Not Just HTTP](../concepts/not-just-http.md)** - Accordant works for any stateful class, not just REST APIs
 
 ---
 

--- a/docs/tutorials/05-testing-race-conditions.md
+++ b/docs/tutorials/05-testing-race-conditions.md
@@ -297,7 +297,6 @@ You don't write concurrent test cases manually. Define the operations and inputs
 ## What's Next?
 
 - **[Tutorial 6: Async Operations](06-async-operations-polling.md)** - Testing background processing
-- **[Concept: Concurrent Test Validation](../concepts/concurrent-test-validation.md)** - How linearizability checking works
 
 ---
 

--- a/docs/tutorials/06-async-operations-polling.md
+++ b/docs/tutorials/06-async-operations-polling.md
@@ -452,13 +452,6 @@ public class JobQueueSpec : Spec<JobQueueState>
 
 ---
 
-## What's Next?
-
-- **[Concept: Step Functions](../concepts/step-functions.md)** - Deeper dive into the model
-- **[How-To: Model Async Background Processing](../how-to/model-async-background-processing.md)** - More patterns
-
----
-
 ## Full Code Reference
 
 See the complete JobQueue sample:


### PR DESCRIPTION
- Fix typo: step-functions-async.md -> step-functions-and-async.md (concepts/what-is-model-based-testing.md)
- Fix relative path: step-functions-and-async.md -> ../concepts/step-functions-and-async.md (how-to/indefinite-failures.md)
- Remove links to unwritten articles: not-just-http.md, concurrent-test-validation.md, step-functions.md, model-async-background-processing.md
- Fix NuGet URLs: nuget.org -> www.nuget.org (3 references)
- Point README API Reference to deployed docs site URL