### PR TITLE
Support Happens-Before Constraints in Spec.AllowsConcurrent

### DIFF
--- a/Accordant.Operations/Operation/Spec.cs
+++ b/Accordant.Operations/Operation/Spec.cs
@@ -316,6 +316,8 @@ public class Spec<TState> : ISpec where TState : class, IState
         if (happensBefore != null)
         {
             var preds = new Dictionary<int, List<string>>();
+            var succ = new List<int>[steps.Length];
+            var inDegree = new int[steps.Length];
             foreach (var (before, after) in happensBefore)
             {
                 if (before == after)
@@ -333,9 +335,14 @@ public class Spec<TState> : ISpec where TState : class, IState
                 }
 
                 if (!preds.ContainsKey(after))
-                    preds[after] = new List<string>();
+                    preds[after] = [];
                 preds[after].Add(steps[before].StepFunctionId);
+
+                (succ[before] ??= []).Add(after);
+                inDegree[after]++;
             }
+
+            ThrowIfCyclic(succ, inDegree);
 
             for (int i = 0; i < steps.Length; i++)
             {
@@ -368,6 +375,44 @@ public class Spec<TState> : ISpec where TState : class, IState
 
             return (false, failureMessage, null);
         }
+    }
+
+    /// <summary>
+    /// Kahn's algorithm: drain nodes with no remaining predecessors. Any node
+    /// still holding in-degree &gt; 0 afterwards belongs to (or feeds) a cycle.
+    /// O(V+E), negligible for the small N this method handles (linearizability
+    /// itself is O(N!)). Mutates <paramref name="inDegree"/>.
+    /// </summary>
+    private static void ThrowIfCyclic(List<int>[] succ, int[] inDegree)
+    {
+        var queue = new Queue<int>();
+        for (int i = 0; i < inDegree.Length; i++)
+        {
+            if (inDegree[i] == 0) queue.Enqueue(i);
+        }
+
+        int visited = 0;
+        while (queue.Count > 0)
+        {
+            var n = queue.Dequeue();
+            visited++;
+            if (succ[n] == null) continue;
+            foreach (var m in succ[n])
+            {
+                if (--inDegree[m] == 0) queue.Enqueue(m);
+            }
+        }
+
+        if (visited == inDegree.Length) return;
+
+        var cycle = new List<int>();
+        for (int i = 0; i < inDegree.Length; i++)
+        {
+            if (inDegree[i] > 0) cycle.Add(i);
+        }
+        throw new ArgumentException(
+            $"Cycle in happens-before constraints involving indices [{string.Join(", ", cycle)}]: " +
+            $"no linearization can satisfy a cyclic ordering.");
     }
 
     #endregion

--- a/Accordant.Operations/Operation/Spec.cs
+++ b/Accordant.Operations/Operation/Spec.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Accordant;
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
@@ -282,14 +283,67 @@ public class Spec<TState> : ISpec where TState : class, IState
         StateProfile stateProfile,
         IList<(IOperation operation, object request, object response)> concurrentCalls)
     {
-        var concurrentSteps = new List<ContractStepFunction>();
+        return AllowsConcurrent(stateProfile, concurrentCalls, Array.Empty<(int, int)>());
+    }
 
-        foreach (var concurrentCall in concurrentCalls)
+    /// <summary>
+    /// Validates whether the spec allows the observed responses for a set of operations
+    /// that were invoked concurrently, with happens-before constraints.
+    ///
+    /// Each edge (before, after) means the call at index <c>before</c> must be linearized
+    /// before the call at index <c>after</c>. Operations without a happens-before relationship
+    /// are still reordered freely.
+    ///
+    /// This enables linearizability checking for partially ordered histories: derive edges
+    /// from wall-clock precedence (one call completes before another starts) and pass them
+    /// here to prune orderings that violate real-time ordering.
+    /// </summary>
+    /// <param name="stateProfile">The state profile representing possible states before the concurrent operations.</param>
+    /// <param name="concurrentCalls">The list of concurrent operation calls with their requests and responses.</param>
+    /// <param name="happensBefore">Edges (before, after) constraining the linearization order.</param>
+    /// <returns>A tuple of (isValid, explanationMessage, updatedStateProfile).</returns>
+    public (bool IsValid, string Message, StateProfile UpdatedStateProfile) AllowsConcurrent(
+        StateProfile stateProfile,
+        IList<(IOperation operation, object request, object response)> concurrentCalls,
+        IEnumerable<(int before, int after)> happensBefore)
+    {
+        // Build step functions first so IDs are stable for edge wiring.
+        var steps = concurrentCalls
+            .Select(c => new ContractStepFunction(
+                c.request, c.response, c.operation.Verify))
+            .ToArray();
+
+        if (happensBefore != null)
         {
-            concurrentSteps.Add(new ContractStepFunction(
-                concurrentCall.request,
-                concurrentCall.response,
-                concurrentCall.operation.Verify));
+            var preds = new Dictionary<int, List<string>>();
+            foreach (var (before, after) in happensBefore)
+            {
+                if (before == after)
+                {
+                    throw new ArgumentException(
+                        $"Self-loop at index {before}: an operation cannot happen before itself.");
+                }
+
+                if (before < 0 || before >= steps.Length ||
+                    after < 0 || after >= steps.Length)
+                {
+                    throw new ArgumentException(
+                        $"Happens-before edge ({before}, {after}) references an index " +
+                        $"outside the range [0, {steps.Length - 1}].");
+                }
+
+                if (!preds.ContainsKey(after))
+                    preds[after] = new List<string>();
+                preds[after].Add(steps[before].StepFunctionId);
+            }
+
+            for (int i = 0; i < steps.Length; i++)
+            {
+                if (preds.TryGetValue(i, out var predecessorIds))
+                {
+                    steps[i].SetPredecessorIds(predecessorIds);
+                }
+            }
         }
 
         try
@@ -297,7 +351,7 @@ public class Spec<TState> : ISpec where TState : class, IState
             stateProfile = SystemChecker.Validate(
                 new IStepFunction[][]
                 {
-                    concurrentSteps.ToArray(),
+                    steps,
                 },
                 stateProfile);
 
@@ -305,8 +359,6 @@ public class Spec<TState> : ISpec where TState : class, IState
         }
         catch (InvalidSpecException ex) when (ex.InnerException is StepFunctionApplicationException)
         {
-            // The spec itself threw an exception - this is a bug in the spec, not an invalid response.
-            // Re-throw so the caller sees it's a spec bug, not a response mismatch.
             throw;
         }
         catch (InvalidSpecException)
@@ -363,7 +415,7 @@ public class Spec<TState> : ISpec where TState : class, IState
     /// <example>
     /// <code>
     /// spec.Operation&lt;(string, string), ApiResult&lt;Todo&gt;&gt;("GetTodo", (req, state) =&gt; { ... });
-    /// 
+    ///
     /// spec.ConfigureDerivations("GetTodo",
     ///     Derive.From&lt;Todo, ApiResult&lt;Todo&gt;, (string, string)&gt;("CreateTodo")
     ///         .When((req, resp) =&gt; resp.IsSuccess)
@@ -401,7 +453,7 @@ public class Spec<TState> : ISpec where TState : class, IState
     /// <example>
     /// <code>
     /// spec.Operation&lt;string, ApiResult&lt;Job&gt;&gt;("CreateJob", (req, state) =&gt; { ... });
-    /// 
+    ///
     /// spec.ConfigurePolling("CreateJob", new PollingSetup
     /// {
     ///     Operation = "GetJob",

--- a/Accordant.Operations/Operation/Spec.cs
+++ b/Accordant.Operations/Operation/Spec.cs
@@ -313,10 +313,10 @@ public class Spec<TState> : ISpec where TState : class, IState
                 c.request, c.response, c.operation.Verify))
             .ToArray();
 
-        if (happensBefore != null)
+        if (happensBefore != null && happensBefore.Count() > 0)
         {
-            var preds = new Dictionary<int, List<string>>();
-            var succ = new List<int>[steps.Length];
+            var predecessorIds = new Dictionary<int, List<string>>();
+            var successors = new Dictionary<int, List<int>>();
             var inDegree = new int[steps.Length];
             foreach (var (before, after) in happensBefore)
             {
@@ -334,21 +334,23 @@ public class Spec<TState> : ISpec where TState : class, IState
                         $"outside the range [0, {steps.Length - 1}].");
                 }
 
-                if (!preds.ContainsKey(after))
-                    preds[after] = [];
-                preds[after].Add(steps[before].StepFunctionId);
+                if (!predecessorIds.ContainsKey(after))
+                    predecessorIds[after] = [];
+                predecessorIds[after].Add(steps[before].StepFunctionId);
 
-                (succ[before] ??= []).Add(after);
+                if (!successors.ContainsKey(before))
+                    successors[before] = [];
+                successors[before].Add(after);
                 inDegree[after]++;
             }
 
-            ThrowIfCyclic(succ, inDegree);
+            ThrowIfCyclic(successors, inDegree);
 
             for (int i = 0; i < steps.Length; i++)
             {
-                if (preds.TryGetValue(i, out var predecessorIds))
+                if (predecessorIds.TryGetValue(i, out var ids))
                 {
-                    steps[i].SetPredecessorIds(predecessorIds);
+                    steps[i].SetPredecessorIds(ids);
                 }
             }
         }
@@ -383,7 +385,7 @@ public class Spec<TState> : ISpec where TState : class, IState
     /// O(V+E), negligible for the small N this method handles (linearizability
     /// itself is O(N!)). Mutates <paramref name="inDegree"/>.
     /// </summary>
-    private static void ThrowIfCyclic(List<int>[] succ, int[] inDegree)
+    private static void ThrowIfCyclic(Dictionary<int, List<int>> successors, int[] inDegree)
     {
         var queue = new Queue<int>();
         for (int i = 0; i < inDegree.Length; i++)
@@ -396,8 +398,8 @@ public class Spec<TState> : ISpec where TState : class, IState
         {
             var n = queue.Dequeue();
             visited++;
-            if (succ[n] == null) continue;
-            foreach (var m in succ[n])
+            if (!successors.TryGetValue(n, out var succList)) continue;
+            foreach (var m in succList)
             {
                 if (--inDegree[m] == 0) queue.Enqueue(m);
             }

--- a/Accordant/StepFunction/ContractStepFunction.cs
+++ b/Accordant/StepFunction/ContractStepFunction.cs
@@ -31,18 +31,41 @@ public class ContractStepFunction : BaseStepFunction
 
     public VerifyFunc Verify { get; private set; }
 
+    private IReadOnlyCollection<string> _predecessorIds;
+
     public ContractStepFunction(
         object request,
         object observedResponse,
-        VerifyFunc verify)
+        VerifyFunc verify,
+        IReadOnlyCollection<string> predecessorIds = null)
     {
         Request = request;
         ObservedResponse = observedResponse;
         Verify = verify ?? throw new ArgumentNullException(nameof(verify));
+        _predecessorIds = predecessorIds ?? Array.Empty<string>();
     }
 
-    protected override IList<StepResult> ApplyInternal(IState state)
+    /// <summary>
+    /// Sets the happens-before predecessor IDs after construction.
+    /// Used to wire edges without replacing the step object (which would change its GUID).
+    /// </summary>
+    public void SetPredecessorIds(IReadOnlyCollection<string> ids)
     {
+        _predecessorIds = ids ?? Array.Empty<string>();
+    }
+
+    protected override IList<StepResult> ApplyInternal(
+        IState state,
+        IReadOnlyList<(IStepFunction, StateGraphNode)> path)
+    {
+        // ponytail: gate on happens-before predecessors; disabled until all are in path.
+        if (_predecessorIds.Count > 0)
+        {
+            var appliedIds = new HashSet<string>(path.Select(p => p.Item1?.StepFunctionId).Where(id => id != null));
+            if (!_predecessorIds.All(id => appliedIds.Contains(id)))
+                return null;
+        }
+
         var (valid, stateProfile) = Verify(
             Request,
             state,

--- a/Tests/Accordant.Operations.Tests/OperationTests.cs
+++ b/Tests/Accordant.Operations.Tests/OperationTests.cs
@@ -911,6 +911,256 @@ public class OperationTests
     }
 
     /// <summary>
+    /// Tests AllowsConcurrent with happens-before edges, enabling linearizability
+    /// checking for partially ordered histories.
+    ///
+    /// Scenario: Write always succeeds and sets state; Read expects response == state.
+    ///   State starts at Value=0.
+    ///   A: Write(1), observed="ok"  (always succeeds)
+    ///   B: Read(),  observed=1      (must see state=1)
+    ///   C: Read(),  observed=1      (must see state=1)
+    ///
+    /// Without edge: [A,B,C] and [A,C,B] both work → true.
+    /// With edge C→A: C must precede A, but C needs A's write → deadlock → false.
+    /// </summary>
+    [Test]
+    public void AllowsConcurrent_WithHappensBefore_PrunesInvalidOrderings()
+    {
+        var spec = new Spec<CounterState>();
+
+        spec.Operation<int, string>("Write", (request, state) =>
+            new ExpectedOutcome(
+                Descriptor.FromValue("ok"),
+                new CounterState(request)));
+
+        spec.Operation<Unit, int>("Read", (request, state) =>
+            new ExpectedOutcome(
+                Descriptor.FromValue(state.Value),
+                state));
+
+        var writeOp = spec.GetOperation<int, string>("Write");
+        var readOp = spec.GetOperation<Unit, int>("Read");
+        var stateProfile = new StateProfile(new CounterState(0));
+
+        var calls = new (IOperation, object, object)[]
+        {
+            (writeOp, 1, "ok"),         // A: Write(1)
+            (readOp, Unit.Value, 1),     // B: Read() observed=1
+            (readOp, Unit.Value, 1),     // C: Read() observed=1
+        };
+
+        // Without edge: valid (A writes 1, both reads see 1)
+        var (noEdgeValid, _, _) = spec.AllowsConcurrent(stateProfile, calls);
+        Assert.IsTrue(noEdgeValid,
+            "Without edge, [A,B,C] and [A,C,B] both work.");
+
+        // With edge C→A: C must precede A, but C needs A's write → no valid ordering
+        var (withEdgeValid, withEdgeMsg, _) = spec.AllowsConcurrent(
+            stateProfile, calls,
+            new[] { (2, 0) });  // C(index 2) → A(index 0)
+
+        Assert.IsFalse(withEdgeValid,
+            "With edge C→A, C must run first but needs state=1 from A. " +
+            $"Got: {withEdgeMsg}");
+    }
+
+    /// <summary>
+    /// Tests that a happens-before edge satisfied by all valid orderings
+    /// doesn't change the result.
+    ///
+    /// Same Write/Read setup as above.
+    /// Edge A→C is already true in every valid ordering (A must write before any Read sees 1),
+    /// so the result is unchanged.
+    /// </summary>
+    [Test]
+    public void AllowsConcurrent_WithHappensBefore_RedundantEdgeDoesNotChangeResult()
+    {
+        var spec = new Spec<CounterState>();
+
+        spec.Operation<int, string>("Write", (request, state) =>
+            new ExpectedOutcome(
+                Descriptor.FromValue("ok"),
+                new CounterState(request)));
+
+        spec.Operation<Unit, int>("Read", (request, state) =>
+            new ExpectedOutcome(
+                Descriptor.FromValue(state.Value),
+                state));
+
+        var writeOp = spec.GetOperation<int, string>("Write");
+        var readOp = spec.GetOperation<Unit, int>("Read");
+        var stateProfile = new StateProfile(new CounterState(0));
+
+        var calls = new (IOperation, object, object)[]
+        {
+            (writeOp, 1, "ok"),
+            (readOp, Unit.Value, 1),
+            (readOp, Unit.Value, 1),
+        };
+
+        var (withEdgeValid, _, nextProfile) = spec.AllowsConcurrent(
+            stateProfile,
+            calls,
+            [(0, 2)]); // A→C (already true in all valid orderings)
+
+        Assert.IsTrue(withEdgeValid,
+            "Edge A→C is trivially satisfied — A must write before any Read sees 1.");
+        Assert.IsNotNull(nextProfile);
+    }
+
+    /// <summary>
+    /// Tests a transitive happens-before chain where one operation is both a
+    /// predecessor and a dependent (A→B→C). This exercises the GUID stability fix:
+    /// when B gets predecessor IDs wired, it must keep its original StepFunctionId
+    /// so that C's reference to B remains valid.
+    ///
+    /// Scenario: Write sets state to request value; Read expects response == state.
+    ///   State starts at Value=0.
+    ///   A: Write(1), observed="ok"
+    ///   B: Write(2), observed="ok"
+    ///   C: Read(),  observed=2  (must see B's write, not A's)
+    ///
+    /// With edges A→B and B→C, only [A,B,C] is a valid ordering.
+    /// </summary>
+    [Test]
+    public void AllowsConcurrent_WithHappensBefore_TransitiveChain()
+    {
+        var spec = new Spec<CounterState>();
+
+        spec.Operation<int, string>("Write", (request, state) =>
+            new ExpectedOutcome(
+                Descriptor.FromValue("ok"),
+                new CounterState(request)));
+
+        spec.Operation<Unit, int>("Read", (request, state) =>
+            new ExpectedOutcome(
+                Descriptor.FromValue(state.Value),
+                state));
+
+        var writeOp = spec.GetOperation<int, string>("Write");
+        var readOp = spec.GetOperation<Unit, int>("Read");
+        var stateProfile = new StateProfile(new CounterState(0));
+
+        var calls = new (IOperation, object, object)[]
+        {
+            (writeOp, 1, "ok"),         // A: Write(1)
+            (writeOp, 2, "ok"),         // B: Write(2)
+            (readOp, Unit.Value, 2),     // C: Read() observed=2
+        };
+
+        // With edges A→B and B→C: only [A,B,C] works.
+        // B is both a predecessor (to C) and a dependent (of A); its GUID
+        // must stay stable when predecessor IDs are wired.
+        var (valid, _, nextProfile) = spec.AllowsConcurrent(
+            stateProfile, calls,
+            new[] { (0, 1), (1, 2) });  // A→B, B→C
+
+        Assert.IsTrue(valid,
+            "With edges A→B and B→C, [A,B,C] is a valid ordering.");
+        Assert.IsNotNull(nextProfile);
+    }
+
+    /// <summary>
+    /// Tests multiple happens-before predecessors for a single operation (A→C, B→C).
+    /// C must wait for both A and B before it can be applied.
+    ///
+    /// Scenario: Write sets state; Read expects response == state.
+    ///   State starts at Value=0.
+    ///   A: Write(1), observed="ok"
+    ///   B: Write(2), observed="ok"
+    ///   C: Read(),  observed=2  (must see B's write after A's)
+    ///
+    /// With edges A→C and B→C, valid orderings are [A,B,C] and [B,A,C].
+    /// In both cases C sees state=2 (B overwrites A's value).
+    /// </summary>
+    [Test]
+    public void AllowsConcurrent_WithHappensBefore_MultiplePredecessors()
+    {
+        var spec = new Spec<CounterState>();
+
+        spec.Operation<int, string>("Write", (request, state) =>
+            new ExpectedOutcome(
+                Descriptor.FromValue("ok"),
+                new CounterState(request)));
+
+        spec.Operation<Unit, int>("Read", (request, state) =>
+            new ExpectedOutcome(
+                Descriptor.FromValue(state.Value),
+                state));
+
+        var writeOp = spec.GetOperation<int, string>("Write");
+        var readOp = spec.GetOperation<Unit, int>("Read");
+        var stateProfile = new StateProfile(new CounterState(0));
+
+        var calls = new (IOperation, object, object)[]
+        {
+            (writeOp, 1, "ok"),         // A: Write(1)
+            (writeOp, 2, "ok"),         // B: Write(2)
+            (readOp, Unit.Value, 2),     // C: Read() observed=2
+        };
+
+        var (valid, _, nextProfile) = spec.AllowsConcurrent(
+            stateProfile, calls,
+            new[] { (0, 2), (1, 2) });  // A→C, B→C
+
+        Assert.IsTrue(valid,
+            "With edges A→C and B→C, both [A,B,C] and [B,A,C] are valid.");
+        Assert.IsNotNull(nextProfile);
+    }
+
+    /// <summary>
+    /// Tests that a self-loop edge throws ArgumentException.
+    /// </summary>
+    [Test]
+    public void AllowsConcurrent_WithHappensBefore_SelfLoopThrows()
+    {
+        var spec = new Spec<CounterState>();
+        spec.Operation<int, string>("Write", (request, state) =>
+            new ExpectedOutcome(
+                Descriptor.FromValue("ok"),
+                new CounterState(request)));
+
+        var writeOp = spec.GetOperation<int, string>("Write");
+        var stateProfile = new StateProfile(new CounterState(0));
+
+        var calls = new (IOperation, object, object)[]
+        {
+            (writeOp, 1, "ok"),
+        };
+
+        var ex = Assert.Throws<ArgumentException>(() =>
+            spec.AllowsConcurrent(stateProfile, calls, new[] { (0, 0) }));
+
+        Assert.That(ex.Message, Does.Contain("Self-loop"));
+    }
+
+    /// <summary>
+    /// Tests that an out-of-range happens-before index throws ArgumentException.
+    /// </summary>
+    [Test]
+    public void AllowsConcurrent_WithHappensBefore_OutOfRangeIndexThrows()
+    {
+        var spec = new Spec<CounterState>();
+        spec.Operation<int, string>("Write", (request, state) =>
+            new ExpectedOutcome(
+                Descriptor.FromValue("ok"),
+                new CounterState(request)));
+
+        var writeOp = spec.GetOperation<int, string>("Write");
+        var stateProfile = new StateProfile(new CounterState(0));
+
+        var calls = new (IOperation, object, object)[]
+        {
+            (writeOp, 1, "ok"),
+        };
+
+        var ex = Assert.Throws<ArgumentException>(() =>
+            spec.AllowsConcurrent(stateProfile, calls, new[] { (0, 1) }));
+
+        Assert.That(ex.Message, Does.Contain("outside the range"));
+    }
+
+    /// <summary>
     /// Tests that ExplainInvalidResponse path throws when spec has a bug.
     /// When response doesn't match and Apply throws during explanation.
     /// Note: ExplainInvalidResponse calls Apply directly (not through SystemChecker.Validate),

--- a/Tests/Accordant.Operations.Tests/OperationTests.cs
+++ b/Tests/Accordant.Operations.Tests/OperationTests.cs
@@ -1135,6 +1135,97 @@ public class OperationTests
     }
 
     /// <summary>
+    /// Tests that a cycle in happens-before edges throws early, rather than
+    /// letting the linearization search fail with a misleading "no ordering" message.
+    /// </summary>
+    [Test]
+    public void AllowsConcurrent_WithHappensBefore_CycleThrows()
+    {
+        var spec = new Spec<CounterState>();
+        spec.Operation<int, string>("Write", (request, state) =>
+            new ExpectedOutcome(
+                Descriptor.FromValue("ok"),
+                new CounterState(request)));
+
+        var writeOp = spec.GetOperation<int, string>("Write");
+        var stateProfile = new StateProfile(new CounterState(0));
+
+        var calls = new (IOperation, object, object)[]
+        {
+            (writeOp, 1, "ok"),
+            (writeOp, 2, "ok"),
+            (writeOp, 3, "ok"),
+        };
+
+        // 0 -> 1 -> 2 -> 0 is a cycle.
+        var ex = Assert.Throws<ArgumentException>(() =>
+            spec.AllowsConcurrent(stateProfile, calls, new[] { (0, 1), (1, 2), (2, 0) }));
+
+        Assert.That(ex.Message, Does.Contain("Cycle"));
+    }
+
+    #region Kahn's algorithm cycle-detection tests
+
+    /// <summary>
+    /// Runs AllowsConcurrent with N idempotent no-op calls and the given edges.
+    /// The operation returns a fixed response and leaves state unchanged, so any
+    /// acyclic edge set linearizes. A "Cycle" ArgumentException therefore comes
+    /// purely from Kahn's, not from linearization failure.
+    /// </summary>
+    private static ArgumentException RunHappensBefore(int n, params (int, int)[] edges)
+    {
+        var spec = new Spec<CounterState>();
+        spec.Operation<int, string>("Noop", (request, state) =>
+            new ExpectedOutcome(Descriptor.FromValue("ok"), state));
+
+        var op = spec.GetOperation<int, string>("Noop");
+        var stateProfile = new StateProfile(new CounterState(0));
+        var calls = new (IOperation, object, object)[n];
+        for (int i = 0; i < n; i++) calls[i] = (op, i, "ok");
+
+        try
+        {
+            var (valid, _, _) = spec.AllowsConcurrent(stateProfile, calls, edges);
+            Assert.IsTrue(valid);
+            return null;
+        }
+        catch (ArgumentException ex) { return ex; }
+    }
+
+    [Test]
+    public void Kahn_Diamond_IsAcyclic()
+    {
+        // 0→1, 0→2, 1→3, 2→3. Node 3 has in-degree 2.
+        // Catches enqueue-on-first-decrement bugs and reversed-edge-direction bugs.
+        Assert.IsNull(RunHappensBefore(4, (0, 1), (0, 2), (1, 3), (2, 3)));
+    }
+
+    [Test]
+    public void Kahn_TwoNodeCycle_IsDetected()
+    {
+        // Smallest non-self cycle. Catches implementations that only see self-loops.
+        var ex = RunHappensBefore(2, (0, 1), (1, 0));
+        Assert.That(ex?.Message, Does.Contain("Cycle"));
+    }
+
+    [Test]
+    public void Kahn_CycleWithTail_ReportsOnlyCycleMembers()
+    {
+        // 0→1→2→3, 3→1. Node 0 drains; {1,2,3} stay stuck.
+        // Catches missed cycles AND wrongly blamed drainable nodes.
+        var ex = RunHappensBefore(4, (0, 1), (1, 2), (2, 3), (3, 1));
+        Assert.That(ex?.Message, Does.Contain("Cycle"));
+
+        var start = ex.Message.IndexOf('[');
+        var end = ex.Message.IndexOf(']');
+        var listed = ex.Message.Substring(start + 1, end - start - 1)
+            .Split(',').Select(s => s.Trim()).ToArray();
+        CollectionAssert.AreEquivalent(new[] { "1", "2", "3" }, listed);
+    }
+
+    #endregion
+
+    /// <summary>
     /// Tests that an out-of-range happens-before index throws ArgumentException.
     /// </summary>
     [Test]


### PR DESCRIPTION
# Add happens-before constraints to `Spec.AllowsConcurrent` for linearizability checking

## Problem

`Spec.AllowsConcurrent` validates a group of concurrent operation calls by searching for some sequential ordering that explains the observed responses. This supports sequential consistency, but **not full linearizability**.

Linearizability additionally requires preserving real-time (wall-clock) precedence: when one operation completes before another begins, the first must appear before the second in the linearization. Today, `AllowsConcurrent` treats all operations as mutually concurrent and freely reorders them, so it cannot distinguish a valid linearization from one that violates real-time ordering.

## Solution

Extend `Spec.AllowsConcurrent` with an optional `happensBefore` parameter:

```csharp
public (bool IsValid, string Message, StateProfile UpdatedStateProfile) AllowsConcurrent(
    StateProfile stateProfile,
    IList<(IOperation operation, object request, object response)> concurrentCalls,
    IEnumerable<(int before, int after)> happensBefore)
```

Each edge `(before, after)` constrains the search to orderings where the call at index `before` appears before the call at index `after`. Operations without a happens-before relationship are still reordered freely.

Callers derive edges from wall-clock timing: whenever one call completes before another starts, add a happens-before edge. Overlapping calls remain unordered. The resulting partial order (a DAG) models any concurrent history.

This is **additive and backward-compatible** — the existing two-parameter overload delegates to the new one with an empty edge set.

## How it works

`ContractStepFunction` already participates in Accordant's state-graph exploration. Each step function can be enabled or disabled depending on the current state. This PR adds a **predecessor gate**: a step function with happens-before predecessors is disabled until all predecessor step IDs appear in the current linearization path.

The path is built by `StateGraph.ExploreStateGraph` as it traverses orderings. When a step function's `ApplyInternal` sees that its predecessors haven't all run yet, it returns `null` (disabled), pruning that branch of the search.

## Files changed

| File | Change |
|------|--------|
| `Accordant/StepFunction/ContractStepFunction.cs` | Added `_predecessorIds` field, `SetPredecessorIds()`, and applies predecessor gate in `ApplyInternal(IState, path)` |
| `Accordant.Operations/Operation/Spec.cs` | Added three-parameter `AllowsConcurrent` overload with edge validation and predecessor wiring |
| `Tests/Accordant.Operations.Tests/OperationTests.cs` | 6 new tests (see below) |

## Tests

| Test | What it covers |
|------|---------------|
| `PrunesInvalidOrderings` | Edge that contradicts the only possible ordering → rejected |
| `RedundantEdgeDoesNotChangeResult` | Edge already satisfied by all valid orderings → accepted |
| `TransitiveChain` | A→B→C where B is both predecessor and dependent → exercises GUID stability |
| `MultiplePredecessors` | A→C and B→C → exercises multi-predecessor accumulation |
| `SelfLoopThrows` | Edge (i, i) throws `ArgumentException` |
| `OutOfRangeIndexThrows` | Edge with index outside bounds throws `ArgumentException` |
