### PR TITLE
Add lazy (on-the-fly) state-graph construction with a unified eager/l…

### DIFF
--- a/Accordant/StateGraph.cs
+++ b/Accordant/StateGraph.cs
@@ -5,7 +5,6 @@ namespace Microsoft.Accordant;
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.IO.Hashing;
 using System.Linq;
 using System.Security.Cryptography;
@@ -36,180 +35,75 @@ public static class StateGraph
         Action<StateGraphNode> hook = null,
         Action<StateGraphNode> postHook = null,
         Func<IState, bool> stateConstraint = null,
-        Func<IState, IStepFunction, StepResult, bool> shouldIncludeStepFunctionResult = null)
+        Func<IState, IStepFunction, StepResult, bool> shouldIncludeStepFunctionResult = null,
+        bool lazy = false)
     {
-        var processedNodeMap = new Dictionary<string, StateGraphNode>();
-        var nodeMap = new Dictionary<string, StateGraphNode>();
-        var parentChildMap = new Dictionary<
-            string,
-            List<(StateGraphNode child, IStepFunction step, object edgeMetadata)>>();
-        var stack = new Stack<(
-            StateGraphNode node,
-            int depth,
-            StateGraphNode parent,
-            IStepFunction parentStep,
-            object edgeMetadata,
-            ImmutableList<(IStepFunction, StateGraphNode)> path)>();
-
-        // Helper method to return a state graph node if it's already been seen,
-        // or create a new one otherwise.
-        StateGraphNode GetOrCreateStateGraphNode(
-            IState state,
-            IList<IStepFunction> stepFunctions)
+        if (lazy && !generateStateGraph)
         {
-            var nodeFingerprint = StateGraphNode.GetNodeFingerprint(
-                state,
-                stepFunctions);
-
-            if (!nodeMap.ContainsKey(nodeFingerprint))
-            {
-                nodeMap[nodeFingerprint] = new StateGraphNode()
-                {
-                    State = state,
-                    StepFunctions = stepFunctions
-                };
-            }
-
-            return nodeMap[nodeFingerprint];
+            throw new ArgumentException(
+                "Lazy exploration builds the graph on demand and therefore requires generateStateGraph = true.",
+                nameof(generateStateGraph));
         }
 
-        var rootGraphNode = GetOrCreateStateGraphNode(
-            startingState,
-            steps.OrderBy(s => s.StepFunctionId).ToList());
+        var expander = new StateGraphExpander(
+            maxDepth,
+            stateConstraint,
+            shouldIncludeStepFunctionResult,
+            hook,
+            postHook,
+            lazy);
 
-        stack.Push((
-            rootGraphNode,
-            1,
-            null,
-            null,
-            null,
-            ImmutableList<(IStepFunction, StateGraphNode)>.Empty.Add((null, rootGraphNode))));
+        var rootGraphNode = expander.GetOrCreateNode(
+            startingState,
+            steps.OrderBy(s => s.StepFunctionId).ToList(),
+            discoveredFrom: null,
+            discoveredVia: null,
+            depth: 1);
+
+        if (lazy)
+        {
+            // Return a root whose outgoing edges (and, transitively, the
+            // whole reachable graph) materialize on demand as the graph is
+            // walked — e.g. by the model-checking emptiness search, which
+            // then stops at the first counterexample without ever building
+            // the unreached remainder of the graph.
+            return rootGraphNode;
+        }
+
+        // Eager exploration: drive the same per-node expansion over a
+        // worklist so every reachable node is materialized up front. Each
+        // node is expanded at most once (its first pop); the resulting edges
+        // are stored on the node and their targets are queued for expansion.
+        // Both the traversal path and the depth handed to expansion are read
+        // from each node (reconstructed from its discovery back-pointers),
+        // exactly as in lazy mode, so the worklist carries only the nodes.
+        var processed = new HashSet<string>();
+        var stack = new Stack<StateGraphNode>();
+
+        stack.Push(rootGraphNode);
 
         while (stack.Count > 0)
         {
-            var (node, depth, parent, parentStep, edgeMetadata, path) = stack.Pop();
+            var node = stack.Pop();
 
-            if (maxDepth != -1 && depth > maxDepth)
+            if (!processed.Add(node.GetNodeFingerprint()))
             {
                 continue;
             }
 
-            if (stateConstraint != null && !stateConstraint(node.State))
+            var edges = expander.ExpandNode(node);
+
+            if (generateStateGraph)
             {
-                continue;
+                node.SetExpandedEdges(edges);
             }
 
-            if (generateStateGraph && parent != null)
+            foreach (var edge in edges)
             {
-                var parentFingerprint = parent.GetNodeFingerprint();
-
-                if (!parentChildMap.ContainsKey(parentFingerprint))
+                var child = edge.Target;
+                if (!processed.Contains(child.GetNodeFingerprint()))
                 {
-                    parentChildMap[parentFingerprint] =
-                        new List<(StateGraphNode child, IStepFunction step, object edgeMetadata)>();
-                }
-
-                parentChildMap[parentFingerprint].Add((node, parentStep, edgeMetadata));
-            }
-
-            var fingerprint = node.GetNodeFingerprint();
-            if (processedNodeMap.ContainsKey(fingerprint))
-            {
-                continue;
-            }
-
-            processedNodeMap[fingerprint] = node;
-
-            var state = node.State;
-            var stepFunctions = node.StepFunctions;
-
-            if (hook != null)
-            {
-                hook(node);
-            }
-
-            foreach (var stepFunction in stepFunctions)
-            {
-                IList<StepResult> stepResults;
-
-                try
-                {
-                    stepResults = stepFunction.Apply(state, path);
-                }
-                catch (Exception ex)
-                {
-                    throw new StepFunctionApplicationException(
-                        ex,
-                        node,
-                        path,
-                        stepFunction);
-                }
-
-                if (stepResults == null || stepResults.Count == 0)
-                {
-                    continue;
-                }
-
-                foreach (var stepResult in stepResults)
-                {
-                    if (shouldIncludeStepFunctionResult != null &&
-                        !shouldIncludeStepFunctionResult(
-                        state,
-                        stepFunction,
-                        stepResult))
-                    {
-                        continue;
-                    }
-
-                    var newStepFunctions = stepFunctions.Where(s => s.StepFunctionId != stepFunction.StepFunctionId).ToList();
-                    if (stepResult.StepFunctions != null)
-                    {
-                        newStepFunctions.AddRange(stepResult.StepFunctions);
-                    }
-
-                    var nextGraphNode = GetOrCreateStateGraphNode(
-                        stepResult.State,
-                        newStepFunctions.OrderBy(s => s.StepFunctionId).ToList());
-
-                    stack.Push((
-                        nextGraphNode,
-                        depth + 1,
-                        node,
-                        stepFunction,
-                        stepResult.EdgeMetadata,
-                        path.Add((stepFunction, nextGraphNode))));
-                }
-            }
-
-            if (postHook != null)
-            {
-                postHook(node);
-            }
-        }
-
-        if (generateStateGraph)
-        {
-            foreach (var kvp in parentChildMap)
-            {
-                var parentFingerprint = kvp.Key;
-                var parent = processedNodeMap[parentFingerprint];
-
-                foreach (var (child, step, edgeMetadata) in kvp.Value)
-                {
-                    var childFingerprint = child.GetNodeFingerprint();
-                    var exists = parent.Edges.Any(e =>
-                        e.StepFunction.StepFunctionId == step.StepFunctionId &&
-                        e.Target.GetNodeFingerprint() == childFingerprint);
-
-                    if (!exists)
-                    {
-                        parent.Edges.Add(new StateGraphEdge()
-                        {
-                            StepFunction = step,
-                            Target = child,
-                            Metadata = edgeMetadata
-                        });
-                    }
+                    stack.Push(child);
                 }
             }
         }
@@ -217,6 +111,86 @@ public static class StateGraph
         return generateStateGraph ?
             rootGraphNode :
             null;
+    }
+
+    /// <summary>
+    /// Generates the raw successors of a node — the single source of truth
+    /// for successor generation shared by eager
+    /// (<see cref="ExploreStateGraph"/>) and lazy
+    /// (<see cref="StateGraphExpander.ExpandNode"/>) construction.
+    ///
+    /// <para>For each step function attached to the node it invokes
+    /// <see cref="IStepFunction.Apply"/> (wrapping failures in a
+    /// <see cref="StepFunctionApplicationException"/>), skips empty results,
+    /// applies the optional <paramref name="shouldIncludeStepFunctionResult"/>
+    /// filter, and computes the successor's step-function set (the current
+    /// step consumed, any newly-produced steps added, ordered by id).</para>
+    ///
+    /// <para>It deliberately does <em>not</em> apply the
+    /// <c>stateConstraint</c> or <c>maxDepth</c> bounds, perform node
+    /// interning, or build edges: those differ between the eager and lazy
+    /// drivers and remain each driver's responsibility. Keeping only the
+    /// path-independent per-step logic here guarantees the two drivers can
+    /// never silently diverge on how a successor state and its step-function
+    /// set are derived.</para>
+    /// </summary>
+    internal static IEnumerable<(
+        IStepFunction stepFunction,
+        IState childState,
+        IList<IStepFunction> childStepFunctions,
+        object edgeMetadata)> GenerateSuccessors(
+        StateGraphNode node,
+        IReadOnlyList<(IStepFunction, StateGraphNode)> path,
+        Func<IState, IStepFunction, StepResult, bool> shouldIncludeStepFunctionResult)
+    {
+        var state = node.State;
+        var stepFunctions = node.StepFunctions;
+
+        foreach (var stepFunction in stepFunctions)
+        {
+            IList<StepResult> stepResults;
+
+            try
+            {
+                stepResults = stepFunction.Apply(state, path);
+            }
+            catch (Exception ex)
+            {
+                throw new StepFunctionApplicationException(
+                    ex,
+                    node,
+                    path.ToList(),
+                    stepFunction);
+            }
+
+            if (stepResults == null || stepResults.Count == 0)
+            {
+                continue;
+            }
+
+            foreach (var stepResult in stepResults)
+            {
+                if (shouldIncludeStepFunctionResult != null &&
+                    !shouldIncludeStepFunctionResult(state, stepFunction, stepResult))
+                {
+                    continue;
+                }
+
+                var newStepFunctions = stepFunctions
+                    .Where(s => s.StepFunctionId != stepFunction.StepFunctionId)
+                    .ToList();
+                if (stepResult.StepFunctions != null)
+                {
+                    newStepFunctions.AddRange(stepResult.StepFunctions);
+                }
+
+                yield return (
+                    stepFunction,
+                    stepResult.State,
+                    newStepFunctions.OrderBy(s => s.StepFunctionId).ToList(),
+                    stepResult.EdgeMetadata);
+            }
+        }
     }
 }
 
@@ -244,10 +218,140 @@ public class StateGraphNode
     /// </summary>
     public IList<IStepFunction> StepFunctions { get; set; }
 
+    private List<StateGraphEdge> edges = new List<StateGraphEdge>();
+
+    private bool expanded;
+
+    /// <summary>
+    /// The expander that lazily computes this node's outgoing edges the
+    /// first time <see cref="Edges"/> is accessed. Non-<c>null</c> only for
+    /// nodes produced by lazy (on-the-fly) exploration
+    /// (<c>StateGraph.ExploreStateGraph(..., lazy: true)</c>). For eagerly
+    /// explored or manually constructed nodes this is <c>null</c> and the
+    /// lazy machinery is inert — <see cref="Edges"/> behaves as a plain list.
+    /// </summary>
+    internal StateGraphExpander Expander { get; set; }
+
+    /// <summary>
+    /// Discovery depth of this node (root = 1), set once when the node is
+    /// first created. Both eager and lazy expansion read it to create
+    /// successors at <c>Depth + 1</c> and to honor the construction-time
+    /// <c>maxDepth</c> bound.
+    /// </summary>
+    internal int Depth { get; set; }
+
+    /// <summary>
+    /// The node from which this node was first discovered (its parent in the
+    /// discovery tree), or <c>null</c> for the root. Together with
+    /// <see cref="DiscoveredVia"/> this forms an immutable, prefix-shared
+    /// chain from any node back to the root — the single source of truth for
+    /// the traversal <see cref="Path"/>, used identically by eager and lazy
+    /// exploration. Set exactly once, when the node is first created.
+    /// </summary>
+    internal StateGraphNode DiscoveredFrom { get; set; }
+
+    /// <summary>
+    /// The step function whose edge first reached this node, or <c>null</c>
+    /// for the root. See <see cref="DiscoveredFrom"/>.
+    /// </summary>
+    internal IStepFunction DiscoveredVia { get; set; }
+
+    private IReadOnlyList<(IStepFunction, StateGraphNode)> materializedPath;
+
+    /// <summary>
+    /// The root→this traversal path handed to step functions during
+    /// expansion, in the shape <c>[(null, root), …, (DiscoveredVia, this)]</c>
+    /// (root first, this node last).
+    ///
+    /// <para>The path is <em>not</em> stored eagerly: it is reconstructed on
+    /// demand by walking the <see cref="DiscoveredFrom"/>/<see cref="DiscoveredVia"/>
+    /// back-pointer chain — which is O(1) memory per node and structurally
+    /// shared across descendants — and then flattened once and memoized here,
+    /// so repeat readers never recompute. Eager and lazy exploration derive
+    /// the path the same way, so a given node is handed an identical path in
+    /// either mode.</para>
+    ///
+    /// <para>This is the <em>discovery</em> witness path: interning means a
+    /// node is expanded at most once, so exactly one of the (possibly many)
+    /// root→node paths is materialized. Because successor generation is
+    /// path-independent, the path only feeds step functions that read history
+    /// (e.g. to prune), never the computed successor set.</para>
+    /// </summary>
+    internal IReadOnlyList<(IStepFunction, StateGraphNode)> Path
+    {
+        get
+        {
+            if (materializedPath == null)
+            {
+                var reversed = new List<(IStepFunction, StateGraphNode)>();
+                for (var node = this; node != null; node = node.DiscoveredFrom)
+                {
+                    reversed.Add((node.DiscoveredVia, node));
+                }
+
+                reversed.Reverse();
+                materializedPath = reversed;
+            }
+
+            return materializedPath;
+        }
+    }
+
     /// <summary>
     /// Edges which lead to the outgoing set of state graph nodes.
+    ///
+    /// <para>For lazily explored nodes the outgoing edges are computed and
+    /// memoized on first access via <see cref="EnsureExpanded"/>. This makes
+    /// on-the-fly model checking transparent to every consumer that walks
+    /// the graph through <see cref="Edges"/> (emptiness checkers, dot
+    /// visualization, BFS traversals) — the graph materializes only as far
+    /// as it is actually walked.</para>
     /// </summary>
-    public List<StateGraphEdge> Edges { get; set; } = new List<StateGraphEdge>();
+    public List<StateGraphEdge> Edges
+    {
+        get
+        {
+            EnsureExpanded();
+            return edges;
+        }
+
+        set => edges = value;
+    }
+
+    /// <summary>
+    /// Ensures this node's outgoing edges have been computed. A no-op for
+    /// eager / manually built nodes (<see cref="Expander"/> is <c>null</c>)
+    /// and idempotent for lazy nodes (expansion runs at most once).
+    /// </summary>
+    internal void EnsureExpanded()
+    {
+        if (expanded)
+        {
+            return;
+        }
+
+        // Mark expanded before invoking the expander so that any re-entrant
+        // access to this node's Edges during expansion returns the
+        // (currently empty) backing list rather than recursing.
+        expanded = true;
+
+        if (Expander != null)
+        {
+            edges = Expander.ComputeEdges(this);
+        }
+    }
+
+    /// <summary>
+    /// Stores the eagerly-computed outgoing edges for this node and marks it
+    /// expanded so that a later <see cref="Edges"/> access is a no-op rather
+    /// than triggering (re)computation. Used by the eager explorer, whose
+    /// worklist has already produced the node's edges.
+    /// </summary>
+    internal void SetExpandedEdges(List<StateGraphEdge> computedEdges)
+    {
+        edges = computedEdges;
+        expanded = true;
+    }
 
     /// <summary>
     /// Returns the node fingerprint which is a hash computed over the state hash

--- a/Accordant/StateGraph.cs
+++ b/Accordant/StateGraph.cs
@@ -223,14 +223,20 @@ public class StateGraphNode
     private bool expanded;
 
     /// <summary>
-    /// The expander that lazily computes this node's outgoing edges the
-    /// first time <see cref="Edges"/> is accessed. Non-<c>null</c> only for
-    /// nodes produced by lazy (on-the-fly) exploration
-    /// (<c>StateGraph.ExploreStateGraph(..., lazy: true)</c>). For eagerly
-    /// explored or manually constructed nodes this is <c>null</c> and the
-    /// lazy machinery is inert — <see cref="Edges"/> behaves as a plain list.
+    /// The expander bound to this node in lazy (on-the-fly) exploration, which
+    /// computes the node's outgoing edges the first time <see cref="Edges"/> is
+    /// accessed. This is the single flag distinguishing the two modes:
+    /// <list type="bullet">
+    /// <item><c>null</c> ⇒ an <b>eager</b> (or manually constructed) node. The
+    /// eager worklist has already computed and stored its edges via
+    /// <see cref="SetExpandedEdges"/>, so the lazy machinery is inert and
+    /// <see cref="Edges"/> behaves as a plain list.</item>
+    /// <item>non-<c>null</c> ⇒ a <b>lazy</b> node
+    /// (<c>StateGraph.ExploreStateGraph(..., lazy: true)</c>) that materializes
+    /// its edges on first <see cref="Edges"/> access.</item>
+    /// </list>
     /// </summary>
-    internal StateGraphExpander Expander { get; set; }
+    internal StateGraphExpander LazyExpander { get; set; }
 
     /// <summary>
     /// Discovery depth of this node (root = 1), set once when the node is
@@ -320,7 +326,7 @@ public class StateGraphNode
 
     /// <summary>
     /// Ensures this node's outgoing edges have been computed. A no-op for
-    /// eager / manually built nodes (<see cref="Expander"/> is <c>null</c>)
+    /// eager / manually built nodes (<see cref="LazyExpander"/> is <c>null</c>)
     /// and idempotent for lazy nodes (expansion runs at most once).
     /// </summary>
     internal void EnsureExpanded()
@@ -335,9 +341,9 @@ public class StateGraphNode
         // (currently empty) backing list rather than recursing.
         expanded = true;
 
-        if (Expander != null)
+        if (LazyExpander != null)
         {
-            edges = Expander.ComputeEdges(this);
+            edges = LazyExpander.ExpandNode(this);
         }
     }
 
@@ -349,6 +355,17 @@ public class StateGraphNode
     /// </summary>
     internal void SetExpandedEdges(List<StateGraphEdge> computedEdges)
     {
+        // Eager and lazy are mutually exclusive per node: an eager node must
+        // never be lazy-bound, or a later Edges access would re-expand it
+        // (with an empty path) and overwrite these edges. Guard explicitly so
+        // the invariant fails loudly in every build, not just DEBUG.
+        if (LazyExpander != null)
+        {
+            throw new InvalidOperationException(
+                "SetExpandedEdges is the eager store path and must not be called on a " +
+                "lazy-bound node (LazyExpander != null).");
+        }
+
         edges = computedEdges;
         expanded = true;
     }

--- a/Accordant/StateGraphExpander.cs
+++ b/Accordant/StateGraphExpander.cs
@@ -1,0 +1,188 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Accordant;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+/// <summary>
+/// The single driver for state-graph construction, shared by both the eager
+/// and the lazy (on-the-fly) exploration modes so that the two apply the
+/// state constraint, depth bound, node interning, edge de-duplication and
+/// pre/post hooks in exactly the same way. Every node — in either mode — is
+/// expanded through <see cref="ExpandNode"/>.
+///
+/// <para>The modes differ in only three, deliberate, ways:</para>
+/// <list type="number">
+/// <item><b>Who drives expansion.</b> The eager explorer
+/// (<see cref="StateGraph.ExploreStateGraph"/>) walks a worklist and expands
+/// every reachable node up front. The lazy driver expands a node the first
+/// time its <see cref="StateGraphNode.Edges"/> are accessed
+/// (<see cref="StateGraphNode.EnsureExpanded"/>), which is what lets model
+/// checking stop at the first counterexample without materializing the
+/// unreached remainder of the graph.</item>
+/// <item><b>The traversal path handed to step functions.</b> Both modes
+/// hand step functions the same reconstructed root→node
+/// <see cref="StateGraphNode.Path"/> (walked from the node's discovery
+/// back-pointers), so a given node is expanded with an identical path in
+/// either mode. Successor generation is path-independent for model
+/// programs; the path only feeds step functions that read history.</item>
+/// <item><b>Whether created nodes self-expand.</b> Lazy nodes carry a back
+/// reference to this expander (<see cref="StateGraphNode.Expander"/>) so
+/// their edges materialize on demand; eager nodes do not, since the worklist
+/// has already computed and stored their edges.</item>
+/// </list>
+/// </summary>
+internal sealed class StateGraphExpander
+{
+    private readonly int maxDepth;
+    private readonly Func<IState, bool> stateConstraint;
+    private readonly Func<IState, IStepFunction, StepResult, bool> shouldIncludeStepFunctionResult;
+    private readonly Action<StateGraphNode> hook;
+    private readonly Action<StateGraphNode> postHook;
+    private readonly bool lazy;
+
+    // Shared fingerprint -> node intern map. Guarantees that two paths
+    // reaching the same (state, step-functions) fingerprint resolve to the
+    // same node object, so a state's edges are computed at most once and the
+    // graph stays a proper DAG-with-cycles.
+    private readonly Dictionary<string, StateGraphNode> nodeMap =
+        new Dictionary<string, StateGraphNode>();
+
+    public StateGraphExpander(
+        int maxDepth,
+        Func<IState, bool> stateConstraint,
+        Func<IState, IStepFunction, StepResult, bool> shouldIncludeStepFunctionResult,
+        Action<StateGraphNode> hook,
+        Action<StateGraphNode> postHook,
+        bool lazy)
+    {
+        this.maxDepth = maxDepth;
+        this.stateConstraint = stateConstraint;
+        this.shouldIncludeStepFunctionResult = shouldIncludeStepFunctionResult;
+        this.hook = hook;
+        this.postHook = postHook;
+        this.lazy = lazy;
+    }
+
+    /// <summary>
+    /// Returns the interned node for a given (state, step-functions) pair,
+    /// creating a fresh node if it has not been seen before. A newly created
+    /// node records the parent and edge it was first reached through
+    /// (<see cref="StateGraphNode.DiscoveredFrom"/>/<see cref="StateGraphNode.DiscoveredVia"/>)
+    /// so its traversal <see cref="StateGraphNode.Path"/> can be reconstructed
+    /// on demand. In lazy mode the new node is bound to this expander so it
+    /// expands on first <see cref="StateGraphNode.Edges"/> access; in eager
+    /// mode it is left unbound because the worklist expands it directly. An
+    /// existing node keeps its original discovery back-pointer and
+    /// <see cref="StateGraphNode.Depth"/>.
+    /// </summary>
+    internal StateGraphNode GetOrCreateNode(
+        IState state,
+        IList<IStepFunction> stepFunctions,
+        StateGraphNode discoveredFrom,
+        IStepFunction discoveredVia,
+        int depth)
+    {
+        var fingerprint = StateGraphNode.GetNodeFingerprint(state, stepFunctions);
+
+        if (!nodeMap.TryGetValue(fingerprint, out var node))
+        {
+            node = new StateGraphNode
+            {
+                State = state,
+                StepFunctions = stepFunctions,
+                Expander = this.lazy ? this : null,
+                DiscoveredFrom = discoveredFrom,
+                DiscoveredVia = discoveredVia,
+                Depth = depth
+            };
+
+            nodeMap[fingerprint] = node;
+        }
+
+        return node;
+    }
+
+    /// <summary>
+    /// The lazy on-demand entry point, invoked from
+    /// <see cref="StateGraphNode.EnsureExpanded"/> the first time a node's
+    /// edges are accessed.
+    /// </summary>
+    internal List<StateGraphEdge> ComputeEdges(StateGraphNode node)
+        => ExpandNode(node);
+
+    /// <summary>
+    /// Expands a single node — the one place both modes compute a node's
+    /// outgoing edges. A node failing the state constraint contributes no
+    /// edges and fires no hook. Otherwise the pre-hook runs, successors are
+    /// drawn from the path-independent
+    /// <see cref="StateGraph.GenerateSuccessors"/> kernel (handed the node's
+    /// reconstructed root→node <see cref="StateGraphNode.Path"/>), each
+    /// successor is filtered by the state constraint and the depth bound, the
+    /// surviving target states are interned — recording the discovery
+    /// back-pointer and depth — and recorded as de-duplicated edges, and the
+    /// post-hook runs.
+    ///
+    /// <para>Both the traversal path and the depth are read from the node
+    /// itself (<see cref="StateGraphNode.Path"/> / <see cref="StateGraphNode.Depth"/>),
+    /// set once at discovery, so eager and lazy expand a given node
+    /// identically without either driver having to thread that context.</para>
+    /// </summary>
+    /// <param name="node">The node to expand; successors are created at
+    /// <see cref="StateGraphNode.Depth"/> + 1.</param>
+    internal List<StateGraphEdge> ExpandNode(StateGraphNode node)
+    {
+        var edges = new List<StateGraphEdge>();
+
+        // A node failing the state constraint is treated as having no
+        // successors and is not hooked.
+        if (stateConstraint != null && !stateConstraint(node.State))
+        {
+            return edges;
+        }
+
+        hook?.Invoke(node);
+
+        var childDepth = node.Depth + 1;
+        var withinDepth = maxDepth == -1 || childDepth <= maxDepth;
+
+        foreach (var (stepFunction, childState, childStepFunctions, edgeMetadata) in
+            StateGraph.GenerateSuccessors(node, node.Path, shouldIncludeStepFunctionResult))
+        {
+            // Drop edges leading to constraint-violating states or beyond the
+            // depth bound; such targets never become nodes or edges.
+            if (stateConstraint != null && !stateConstraint(childState))
+            {
+                continue;
+            }
+
+            if (!withinDepth)
+            {
+                continue;
+            }
+
+            var child = GetOrCreateNode(childState, childStepFunctions, node, stepFunction, childDepth);
+
+            var childFingerprint = child.GetNodeFingerprint();
+            var alreadyPresent = edges.Any(e =>
+                e.StepFunction.StepFunctionId == stepFunction.StepFunctionId &&
+                e.Target.GetNodeFingerprint() == childFingerprint);
+
+            if (!alreadyPresent)
+            {
+                edges.Add(new StateGraphEdge
+                {
+                    StepFunction = stepFunction,
+                    Target = child,
+                    Metadata = edgeMetadata
+                });
+            }
+        }
+
+        postHook?.Invoke(node);
+        return edges;
+    }
+}

--- a/Accordant/StateGraphExpander.cs
+++ b/Accordant/StateGraphExpander.cs
@@ -30,7 +30,7 @@ using System.Linq;
 /// either mode. Successor generation is path-independent for model
 /// programs; the path only feeds step functions that read history.</item>
 /// <item><b>Whether created nodes self-expand.</b> Lazy nodes carry a back
-/// reference to this expander (<see cref="StateGraphNode.Expander"/>) so
+/// reference to this expander (<see cref="StateGraphNode.LazyExpander"/>) so
 /// their edges materialize on demand; eager nodes do not, since the worklist
 /// has already computed and stored their edges.</item>
 /// </list>
@@ -94,7 +94,7 @@ internal sealed class StateGraphExpander
             {
                 State = state,
                 StepFunctions = stepFunctions,
-                Expander = this.lazy ? this : null,
+                LazyExpander = this.lazy ? this : null,
                 DiscoveredFrom = discoveredFrom,
                 DiscoveredVia = discoveredVia,
                 Depth = depth
@@ -107,16 +107,11 @@ internal sealed class StateGraphExpander
     }
 
     /// <summary>
-    /// The lazy on-demand entry point, invoked from
-    /// <see cref="StateGraphNode.EnsureExpanded"/> the first time a node's
-    /// edges are accessed.
-    /// </summary>
-    internal List<StateGraphEdge> ComputeEdges(StateGraphNode node)
-        => ExpandNode(node);
-
-    /// <summary>
     /// Expands a single node — the one place both modes compute a node's
-    /// outgoing edges. A node failing the state constraint contributes no
+    /// outgoing edges. It is the eager worklist's per-node step and, via
+    /// <see cref="StateGraphNode.EnsureExpanded"/>, the lazy on-demand entry
+    /// point invoked the first time a node's edges are accessed.
+    /// A node failing the state constraint contributes no
     /// edges and fires no hook. Otherwise the pre-hook runs, successors are
     /// drawn from the path-independent
     /// <see cref="StateGraph.GenerateSuccessors"/> kernel (handed the node's

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <NoWarn>CS1591</NoWarn>
     
     <!-- NuGet Package Defaults -->
-    <Version>0.1.6</Version>
+    <Version>0.1.7</Version>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
     <Copyright>Copyright (c) 2024-2026 Microsoft Corporation</Copyright>

--- a/Tests/Accordant.Tests/LazyEagerEquivalenceTests.cs
+++ b/Tests/Accordant.Tests/LazyEagerEquivalenceTests.cs
@@ -32,12 +32,11 @@ using NUnit.Framework;
 /// each other.</item>
 /// </list>
 ///
-/// <para>Two further eager-only invariants guard the risk surface exercised
-/// in production on this branch (there is no production lazy consumer here):
-/// eager exploration is <em>deterministic</em> across repeated runs, and the
-/// memory-lean <c>generateStateGraph:false</c> traversal (used by
-/// <c>SystemChecker</c>, which retains no edges) still fires its pre- and
-/// post-hooks on exactly the same node set as the full eager graph.</para>
+/// <para>Two further eager-only invariants: eager exploration is
+/// <em>deterministic</em> across repeated runs, and the memory-lean
+/// <c>generateStateGraph:false</c> traversal (used by <c>SystemChecker</c>,
+/// which retains no edges) still fires its pre- and post-hooks on exactly
+/// the same node set as the full eager graph.</para>
 /// </summary>
 [TestFixture]
 public class LazyEagerEquivalenceTests

--- a/Tests/Accordant.Tests/LazyEagerEquivalenceTests.cs
+++ b/Tests/Accordant.Tests/LazyEagerEquivalenceTests.cs
@@ -1,0 +1,329 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Accordant.Tests;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Accordant;
+using NUnit.Framework;
+
+/// <summary>
+/// Property-based (randomized/generative) tests asserting that eager and
+/// lazy state-graph construction are equivalent — they now share a single
+/// successor kernel (<c>StateGraph.GenerateSuccessors</c>), so any divergence
+/// is a bug. These tests exercise only the core graph-construction contract
+/// (nodes, edges, hooks, constraints, depth bounds); equivalence of the
+/// model-checking verdicts built on top of the graph is covered separately
+/// in the model-checking test project.
+///
+/// <para>The <em>invariants</em> asserted, and the one place the two may
+/// legitimately differ:</para>
+/// <list type="bullet">
+/// <item>Unbounded (<c>maxDepth == -1</c>): the eager and lazy graphs are
+/// identical as a set of nodes and a set of edges, and they hook exactly the
+/// same set of nodes.</item>
+/// <item>Bounded (<c>maxDepth &gt;= 0</c>): depth is memoized at first
+/// discovery, and discovery order differs (eager DFS stack vs. lazy
+/// consumer-driven walk), so the two truncated graphs may genuinely differ.
+/// We therefore assert only the order-independent invariant that <em>each</em>
+/// bounded graph is a subgraph of the unbounded one — not that they equal
+/// each other.</item>
+/// </list>
+/// </summary>
+[TestFixture]
+public class LazyEagerEquivalenceTests
+{
+    private const int Seeds = 200;
+
+    #region Randomized model
+
+    private sealed class VectorState : State
+    {
+        public int[] Values { get; set; }
+
+        protected override void CloneInternal(Dictionary<object, object> clonedMap)
+            => clonedMap[this] = new VectorState { Values = (int[])this.Values.Clone() };
+
+        protected override string StringRepresentationInternal(
+            Dictionary<object, string> objectPaths, string path, bool forceRecompute)
+            => "V=[" + string.Join(",", this.Values) + "]";
+
+        protected override void FreezeComponents(HashSet<object> visited)
+        {
+        }
+    }
+
+    // Re-adds itself: moves one component by +/-1 while it stays in [0, bound).
+    private sealed class MoveStep : BaseStepFunction
+    {
+        private readonly string id;
+        private readonly int component;
+        private readonly int delta;
+        private readonly int bound;
+
+        public MoveStep(string id, int component, int delta, int bound)
+        {
+            this.id = id;
+            this.component = component;
+            this.delta = delta;
+            this.bound = bound;
+        }
+
+        public override string StepFunctionId => this.id;
+
+        protected override IList<StepResult> ApplyInternal(IState state)
+        {
+            var s = (VectorState)state;
+            var v = s.Values[this.component] + this.delta;
+            if (v < 0 || v >= this.bound) return null;
+            var next = (VectorState)s.Clone();
+            next.Values[this.component] = v;
+            return new[] { new StepResult { State = next, StepFunctions = new IStepFunction[] { this } } };
+        }
+    }
+
+    // Re-adds itself, but branches non-deterministically: emits both the +1
+    // and -1 in-bounds successors of a component in a single application.
+    private sealed class SpawnStep : BaseStepFunction
+    {
+        private readonly string id;
+        private readonly int component;
+        private readonly int bound;
+
+        public SpawnStep(string id, int component, int bound)
+        {
+            this.id = id;
+            this.component = component;
+            this.bound = bound;
+        }
+
+        public override string StepFunctionId => this.id;
+
+        protected override IList<StepResult> ApplyInternal(IState state)
+        {
+            var s = (VectorState)state;
+            var results = new List<StepResult>();
+            foreach (var delta in new[] { +1, -1 })
+            {
+                var v = s.Values[this.component] + delta;
+                if (v < 0 || v >= this.bound) continue;
+                var next = (VectorState)s.Clone();
+                next.Values[this.component] = v;
+                results.Add(new StepResult { State = next, StepFunctions = new IStepFunction[] { this } });
+            }
+
+            return results.Count == 0 ? null : results;
+        }
+    }
+
+    // Fires once when a component hits a target value, then consumes itself
+    // (adds no step functions), so downstream nodes carry a smaller
+    // step-function set. Exercises the successor step-set computation.
+    private sealed class ConsumeStep : BaseStepFunction
+    {
+        private readonly string id;
+        private readonly int component;
+        private readonly int target;
+
+        public ConsumeStep(string id, int component, int target)
+        {
+            this.id = id;
+            this.component = component;
+            this.target = target;
+        }
+
+        public override string StepFunctionId => this.id;
+
+        protected override IList<StepResult> ApplyInternal(IState state)
+        {
+            var s = (VectorState)state;
+            if (s.Values[this.component] != this.target) return null;
+            var next = (VectorState)s.Clone();
+            // No StepFunctions -> this step is consumed at the successor node.
+            return new[] { new StepResult { State = next, StepFunctions = Array.Empty<IStepFunction>() } };
+        }
+    }
+
+    private static (IStepFunction[] steps, VectorState start) BuildModel(Random rnd)
+    {
+        var dims = rnd.Next(1, 3);       // 1..2
+        var bound = rnd.Next(2, 4);      // 2..3
+        var numSteps = rnd.Next(2, 5);   // 2..4
+
+        var steps = new List<IStepFunction>();
+        var hasMovement = false;
+        for (var i = 0; i < numSteps; i++)
+        {
+            var id = "s" + i;
+            var component = rnd.Next(0, dims);
+            switch (rnd.Next(0, 3))
+            {
+                case 0:
+                    steps.Add(new MoveStep(id, component, rnd.Next(0, 2) == 0 ? +1 : -1, bound));
+                    hasMovement = true;
+                    break;
+                case 1:
+                    steps.Add(new SpawnStep(id, component, bound));
+                    hasMovement = true;
+                    break;
+                default:
+                    steps.Add(new ConsumeStep(id, component, rnd.Next(0, bound)));
+                    break;
+            }
+        }
+
+        // Guarantee a non-trivial graph.
+        if (!hasMovement)
+        {
+            steps.Add(new MoveStep("sMove", 0, +1, bound));
+        }
+
+        return (steps.ToArray(), new VectorState { Values = new int[dims] });
+    }
+
+    #endregion
+
+    #region Graph signatures
+
+    // Fingerprints of every node reachable from the root by walking Edges.
+    private static HashSet<string> NodeSet(StateGraphNode root)
+    {
+        var seen = new HashSet<string>();
+        var stack = new Stack<StateGraphNode>();
+        stack.Push(root);
+        while (stack.Count > 0)
+        {
+            var n = stack.Pop();
+            if (!seen.Add(n.GetNodeFingerprint())) continue;
+            foreach (var e in n.Edges) stack.Push(e.Target);
+        }
+
+        return seen;
+    }
+
+    // "source|stepId|target" for every edge reachable from the root.
+    private static HashSet<string> EdgeSet(StateGraphNode root)
+    {
+        var seenNodes = new HashSet<string>();
+        var edges = new HashSet<string>();
+        var stack = new Stack<StateGraphNode>();
+        stack.Push(root);
+        while (stack.Count > 0)
+        {
+            var n = stack.Pop();
+            var nf = n.GetNodeFingerprint();
+            if (!seenNodes.Add(nf)) continue;
+            foreach (var e in n.Edges)
+            {
+                edges.Add(nf + "|" + e.StepFunction.StepFunctionId + "|" + e.Target.GetNodeFingerprint());
+                stack.Push(e.Target);
+            }
+        }
+
+        return edges;
+    }
+
+    #endregion
+
+    [Test]
+    public void EagerAndLazy_ProduceIdenticalGraphs_WhenUnbounded()
+    {
+        for (var seed = 0; seed < Seeds; seed++)
+        {
+            var (steps, start) = BuildModel(new Random(seed));
+
+            var eagerHooks = new HashSet<string>();
+            var eagerRoot = StateGraph.ExploreStateGraph(
+                steps, (VectorState)start.Clone(),
+                hook: n => eagerHooks.Add(n.GetNodeFingerprint()));
+
+            var lazyHooks = new HashSet<string>();
+            var lazyRoot = StateGraph.ExploreStateGraph(
+                steps, (VectorState)start.Clone(),
+                hook: n => lazyHooks.Add(n.GetNodeFingerprint()),
+                lazy: true);
+
+            var eagerNodes = NodeSet(eagerRoot);
+            var lazyNodes = NodeSet(lazyRoot);      // full walk materializes lazy graph
+            var eagerEdges = EdgeSet(eagerRoot);
+            var lazyEdges = EdgeSet(lazyRoot);
+
+            Assert.That(lazyNodes.SetEquals(eagerNodes), Is.True,
+                $"seed {seed}: node sets differ (eager={eagerNodes.Count}, lazy={lazyNodes.Count})");
+            Assert.That(lazyEdges.SetEquals(eagerEdges), Is.True,
+                $"seed {seed}: edge sets differ (eager={eagerEdges.Count}, lazy={lazyEdges.Count})");
+
+            // Hook alignment: a full walk of the lazy graph fires the hook on
+            // exactly the same set of nodes the eager explorer hooks.
+            Assert.That(lazyHooks.SetEquals(eagerHooks), Is.True,
+                $"seed {seed}: hooked node sets differ");
+            Assert.That(eagerHooks.SetEquals(eagerNodes), Is.True,
+                $"seed {seed}: eager should hook every reachable node exactly once");
+        }
+    }
+
+    [Test]
+    public void BoundedGraphs_AreSubgraphsOfUnbounded_ForBothDrivers()
+    {
+        for (var seed = 0; seed < Seeds; seed++)
+        {
+            var rnd = new Random(seed);
+            var (steps, start) = BuildModel(rnd);
+            var maxDepth = rnd.Next(1, 6);
+
+            var unboundedNodes = NodeSet(
+                StateGraph.ExploreStateGraph(steps, (VectorState)start.Clone()));
+            var unboundedEdges = EdgeSet(
+                StateGraph.ExploreStateGraph(steps, (VectorState)start.Clone()));
+
+            foreach (var lazy in new[] { false, true })
+            {
+                var root = StateGraph.ExploreStateGraph(
+                    steps, (VectorState)start.Clone(), maxDepth: maxDepth, lazy: lazy);
+
+                var boundedNodes = NodeSet(root);
+                var boundedEdges = EdgeSet(root);
+
+                Assert.That(boundedNodes.IsSubsetOf(unboundedNodes), Is.True,
+                    $"seed {seed} lazy={lazy}: bounded nodes must be a subset of the unbounded graph");
+                Assert.That(boundedEdges.IsSubsetOf(unboundedEdges), Is.True,
+                    $"seed {seed} lazy={lazy}: bounded edges must be a subset of the unbounded graph");
+            }
+        }
+    }
+
+    [Test]
+    public void ConstraintFailingRoot_FiresNoHooks_InBothDrivers()
+    {
+        var steps = new IStepFunction[] { new MoveStep("s0", 0, +1, 3) };
+        Func<IState, bool> rejectAll = _ => false;
+
+        var eagerHooks = new List<string>();
+        var eagerPostHooks = new List<string>();
+        StateGraph.ExploreStateGraph(
+            steps, new VectorState { Values = new int[1] },
+            hook: n => eagerHooks.Add(n.GetNodeFingerprint()),
+            postHook: n => eagerPostHooks.Add(n.GetNodeFingerprint()),
+            stateConstraint: rejectAll);
+
+        var lazyHooks = new List<string>();
+        var lazyPostHooks = new List<string>();
+        var lazyRoot = StateGraph.ExploreStateGraph(
+            steps, new VectorState { Values = new int[1] },
+            hook: n => lazyHooks.Add(n.GetNodeFingerprint()),
+            postHook: n => lazyPostHooks.Add(n.GetNodeFingerprint()),
+            stateConstraint: rejectAll,
+            lazy: true);
+
+        // Force lazy expansion of the (constraint-failing) root.
+        var edges = lazyRoot.Edges;
+
+        Assert.That(edges, Is.Empty, "constraint-failing root has no successors");
+        Assert.That(eagerHooks, Is.Empty, "eager must not hook a constraint-failing node");
+        Assert.That(eagerPostHooks, Is.Empty, "eager must not post-hook a constraint-failing node");
+        Assert.That(lazyHooks, Is.Empty, "lazy must not hook a constraint-failing node");
+        Assert.That(lazyPostHooks, Is.Empty, "lazy must not post-hook a constraint-failing node");
+    }
+}

--- a/Tests/Accordant.Tests/LazyEagerEquivalenceTests.cs
+++ b/Tests/Accordant.Tests/LazyEagerEquivalenceTests.cs
@@ -31,11 +31,18 @@ using NUnit.Framework;
 /// bounded graph is a subgraph of the unbounded one — not that they equal
 /// each other.</item>
 /// </list>
+///
+/// <para>Two further eager-only invariants guard the risk surface exercised
+/// in production on this branch (there is no production lazy consumer here):
+/// eager exploration is <em>deterministic</em> across repeated runs, and the
+/// memory-lean <c>generateStateGraph:false</c> traversal (used by
+/// <c>SystemChecker</c>, which retains no edges) still fires its pre- and
+/// post-hooks on exactly the same node set as the full eager graph.</para>
 /// </summary>
 [TestFixture]
 public class LazyEagerEquivalenceTests
 {
-    private const int Seeds = 200;
+    private const int Seeds = 400;
 
     #region Randomized model
 
@@ -148,9 +155,9 @@ public class LazyEagerEquivalenceTests
 
     private static (IStepFunction[] steps, VectorState start) BuildModel(Random rnd)
     {
-        var dims = rnd.Next(1, 3);       // 1..2
-        var bound = rnd.Next(2, 4);      // 2..3
-        var numSteps = rnd.Next(2, 5);   // 2..4
+        var dims = rnd.Next(1, 4);       // 1..3
+        var bound = rnd.Next(2, 5);      // 2..4
+        var numSteps = rnd.Next(2, 6);   // 2..5
 
         var steps = new List<IStepFunction>();
         var hasMovement = false;
@@ -325,5 +332,71 @@ public class LazyEagerEquivalenceTests
         Assert.That(eagerPostHooks, Is.Empty, "eager must not post-hook a constraint-failing node");
         Assert.That(lazyHooks, Is.Empty, "lazy must not hook a constraint-failing node");
         Assert.That(lazyPostHooks, Is.Empty, "lazy must not post-hook a constraint-failing node");
+    }
+
+    [Test]
+    public void EagerExploration_IsDeterministic_AcrossRepeatedRuns()
+    {
+        for (var seed = 0; seed < Seeds; seed++)
+        {
+            var (steps, start) = BuildModel(new Random(seed));
+
+            var hooksA = new HashSet<string>();
+            var rootA = StateGraph.ExploreStateGraph(
+                steps, (VectorState)start.Clone(),
+                hook: n => hooksA.Add(n.GetNodeFingerprint()));
+
+            // Re-run the same model with the same (stateless) step instances;
+            // interning, ordering and hook firing must reproduce exactly.
+            var hooksB = new HashSet<string>();
+            var rootB = StateGraph.ExploreStateGraph(
+                steps, (VectorState)start.Clone(),
+                hook: n => hooksB.Add(n.GetNodeFingerprint()));
+
+            Assert.That(NodeSet(rootB).SetEquals(NodeSet(rootA)), Is.True,
+                $"seed {seed}: repeated eager runs produced different node sets");
+            Assert.That(EdgeSet(rootB).SetEquals(EdgeSet(rootA)), Is.True,
+                $"seed {seed}: repeated eager runs produced different edge sets");
+            Assert.That(hooksB.SetEquals(hooksA), Is.True,
+                $"seed {seed}: repeated eager runs hooked different node sets");
+        }
+    }
+
+    [Test]
+    public void GenerateStateGraphFalse_HooksSameNodes_AsEagerGraph()
+    {
+        for (var seed = 0; seed < Seeds; seed++)
+        {
+            var (steps, start) = BuildModel(new Random(seed));
+
+            // Full eager graph: collect the pre- and post-hooked node sets and
+            // the reachable node set.
+            var graphHooks = new HashSet<string>();
+            var graphPostHooks = new HashSet<string>();
+            var graphRoot = StateGraph.ExploreStateGraph(
+                steps, (VectorState)start.Clone(),
+                hook: n => graphHooks.Add(n.GetNodeFingerprint()),
+                postHook: n => graphPostHooks.Add(n.GetNodeFingerprint()));
+
+            // Memory-lean eager traversal (the SystemChecker mode): it retains
+            // no edges and returns no root, but must still visit — and hook —
+            // exactly the same nodes.
+            var leanHooks = new HashSet<string>();
+            var leanPostHooks = new HashSet<string>();
+            var leanRoot = StateGraph.ExploreStateGraph(
+                steps, (VectorState)start.Clone(),
+                generateStateGraph: false,
+                hook: n => leanHooks.Add(n.GetNodeFingerprint()),
+                postHook: n => leanPostHooks.Add(n.GetNodeFingerprint()));
+
+            Assert.That(leanRoot, Is.Null,
+                $"seed {seed}: generateStateGraph:false must return no graph root");
+            Assert.That(graphHooks.SetEquals(NodeSet(graphRoot)), Is.True,
+                $"seed {seed}: eager should hook every reachable node exactly once");
+            Assert.That(leanHooks.SetEquals(graphHooks), Is.True,
+                $"seed {seed}: lean traversal hooked a different node set than the full graph");
+            Assert.That(leanPostHooks.SetEquals(graphPostHooks), Is.True,
+                $"seed {seed}: lean traversal post-hooked a different node set than the full graph");
+        }
     }
 }

--- a/Tests/Accordant.Tests/StateGraphPathTests.cs
+++ b/Tests/Accordant.Tests/StateGraphPathTests.cs
@@ -1,0 +1,246 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Accordant.Tests;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Accordant;
+using NUnit.Framework;
+
+/// <summary>
+/// Tests for the root→node traversal <c>path</c> that state-graph
+/// construction hands to each step function's
+/// <see cref="BaseStepFunction.Apply"/>. The path is reconstructed on demand
+/// from each node's discovery back-pointers, so:
+/// <list type="bullet">
+/// <item>eager and lazy exploration hand every node an <em>identical</em>
+/// path (the same discovery witness), even when a node is reachable by
+/// several routes (a diamond);</item>
+/// <item>the path is well formed — root first with a null incoming step,
+/// this node last, and every interior element carrying a real step; and</item>
+/// <item>a child's path is exactly its discovery parent's path plus the child
+/// (the "parent's path + this node" construction).</item>
+/// </list>
+/// A separate check confirms the reconstructed path is memoized (repeat reads
+/// return the same instance rather than recomputing).
+/// </summary>
+[TestFixture]
+public class StateGraphPathTests
+{
+    #region Diamond model
+
+    // Two independent bits, each flippable 0 -> 1 exactly once. From (0,0)
+    // the graph is a diamond: (1,1) is reachable both via A-then-B and
+    // B-then-A, so exactly one of those becomes its discovery witness path.
+    private sealed class BitState : State
+    {
+        public int A { get; set; }
+
+        public int B { get; set; }
+
+        protected override void CloneInternal(Dictionary<object, object> clonedMap)
+            => clonedMap[this] = new BitState { A = this.A, B = this.B };
+
+        protected override string StringRepresentationInternal(
+            Dictionary<object, string> objectPaths, string path, bool forceRecompute)
+            => $"({this.A},{this.B})";
+
+        protected override void FreezeComponents(HashSet<object> visited)
+        {
+        }
+    }
+
+    // Flips one bit 0 -> 1, re-adding itself so the step set is stable.
+    // Records the path it was handed, keyed by the expanding node, into the
+    // currently-installed sink. Returns null once the bit is already 1.
+    private sealed class FlipStep : BaseStepFunction
+    {
+        private readonly string id;
+        private readonly bool flipA;
+
+        public FlipStep(string id, bool flipA)
+        {
+            this.id = id;
+            this.flipA = flipA;
+        }
+
+        public override string StepFunctionId => this.id;
+
+        // The map recording, per expanding node, the path handed to Apply.
+        public Dictionary<string, IReadOnlyList<(IStepFunction, StateGraphNode)>> Sink { get; set; }
+
+        protected override IList<StepResult> ApplyInternal(
+            IState state,
+            IReadOnlyList<(IStepFunction, StateGraphNode)> path)
+        {
+            // The node currently being expanded is the last path element.
+            var nodeFingerprint = path[path.Count - 1].Item2.GetNodeFingerprint();
+            if (!this.Sink.ContainsKey(nodeFingerprint))
+            {
+                this.Sink[nodeFingerprint] = path;
+            }
+
+            var s = (BitState)state;
+            var bitIsSet = this.flipA ? s.A == 1 : s.B == 1;
+            if (bitIsSet)
+            {
+                return null;
+            }
+
+            var next = (BitState)s.Clone();
+            if (this.flipA)
+            {
+                next.A = 1;
+            }
+            else
+            {
+                next.B = 1;
+            }
+
+            return new[]
+            {
+                new StepResult { State = next, StepFunctions = new IStepFunction[] { this } },
+            };
+        }
+    }
+
+    #endregion
+
+    private static string Sig(IReadOnlyList<(IStepFunction, StateGraphNode)> path)
+        => string.Join(
+            " -> ",
+            path.Select(e => (e.Item1?.StepFunctionId ?? "ε") + ":" + e.Item2.GetNodeFingerprint()));
+
+    // Walk the whole graph so every node's edges (and, in lazy mode, its
+    // on-demand expansion) are materialized, firing the recording steps.
+    private static void MaterializeAll(StateGraphNode root)
+    {
+        var seen = new HashSet<string>();
+        var stack = new Stack<StateGraphNode>();
+        stack.Push(root);
+        while (stack.Count > 0)
+        {
+            var n = stack.Pop();
+            if (!seen.Add(n.GetNodeFingerprint()))
+            {
+                continue;
+            }
+
+            foreach (var e in n.Edges)
+            {
+                stack.Push(e.Target);
+            }
+        }
+    }
+
+    private static Dictionary<string, IReadOnlyList<(IStepFunction, StateGraphNode)>> RecordPaths(
+        FlipStep[] steps, BitState start, bool lazy, out StateGraphNode root)
+    {
+        var sink = new Dictionary<string, IReadOnlyList<(IStepFunction, StateGraphNode)>>();
+        foreach (var s in steps)
+        {
+            s.Sink = sink;
+        }
+
+        root = StateGraph.ExploreStateGraph(steps, (BitState)start.Clone(), lazy: lazy);
+        MaterializeAll(root);
+        return sink;
+    }
+
+    [Test]
+    public void EagerAndLazy_HandEachNode_TheIdenticalPath()
+    {
+        // Shared step instances so the two runs order steps identically and
+        // therefore discover nodes in the same order.
+        var steps = new[] { new FlipStep("A", flipA: true), new FlipStep("B", flipA: false) };
+        var start = new BitState { A = 0, B = 0 };
+
+        var eager = RecordPaths(steps, start, lazy: false, out var eagerRoot);
+        var lazy = RecordPaths(steps, start, lazy: true, out _);
+
+        // Sanity: the diamond really merges — all four bit combinations are
+        // reached, including the doubly-reachable (1,1).
+        Assert.That(eager.Count, Is.EqualTo(4), "expected the 4-node diamond to be fully explored");
+
+        Assert.That(lazy.Keys.ToHashSet().SetEquals(eager.Keys), Is.True,
+            "eager and lazy must expand (and record a path for) the same set of nodes");
+
+        foreach (var key in eager.Keys)
+        {
+            Assert.That(Sig(lazy[key]), Is.EqualTo(Sig(eager[key])),
+                $"eager and lazy handed node {key} different paths");
+        }
+    }
+
+    [Test]
+    public void ReconstructedPaths_AreWellFormed_AndPrefixClosed()
+    {
+        var steps = new[] { new FlipStep("A", flipA: true), new FlipStep("B", flipA: false) };
+        var start = new BitState { A = 0, B = 0 };
+
+        var paths = RecordPaths(steps, start, lazy: false, out var root);
+        var rootFingerprint = root.GetNodeFingerprint();
+
+        foreach (var (key, path) in paths.Select(kv => (kv.Key, kv.Value)))
+        {
+            Assert.That(path.Count, Is.GreaterThanOrEqualTo(1), "a path is never empty");
+
+            // Root first, with no incoming step.
+            Assert.That(path[0].Item1, Is.Null, "the first path element (root) has no incoming step");
+            Assert.That(path[0].Item2.GetNodeFingerprint(), Is.EqualTo(rootFingerprint),
+                "every path starts at the root");
+
+            // This node last.
+            Assert.That(path[path.Count - 1].Item2.GetNodeFingerprint(), Is.EqualTo(key),
+                "a path ends at the node it belongs to");
+
+            // Only the root element lacks an incoming step.
+            for (var i = 1; i < path.Count; i++)
+            {
+                Assert.That(path[i].Item1, Is.Not.Null,
+                    "every non-root path element carries the step that reached it");
+            }
+
+            // Prefix closure: child path == discovery-parent path + child.
+            if (path.Count >= 2)
+            {
+                var parentFingerprint = path[path.Count - 2].Item2.GetNodeFingerprint();
+                Assert.That(paths.ContainsKey(parentFingerprint), Is.True,
+                    "the discovery parent must itself have been expanded");
+
+                var expectedParentSig = Sig(path.Take(path.Count - 1).ToList());
+                Assert.That(Sig(paths[parentFingerprint]), Is.EqualTo(expectedParentSig),
+                    "a node's path must be exactly its discovery parent's path plus itself");
+            }
+        }
+    }
+
+    [Test]
+    public void ReconstructedPath_IsMemoized_SoRepeatReadsDoNotRecompute()
+    {
+        var steps = new[] { new FlipStep("A", flipA: true), new FlipStep("B", flipA: false) };
+        foreach (var s in steps)
+        {
+            s.Sink = new Dictionary<string, IReadOnlyList<(IStepFunction, StateGraphNode)>>();
+        }
+
+        var root = StateGraph.ExploreStateGraph(steps, new BitState { A = 0, B = 0 });
+
+        // Path is an internal member; read it twice via reflection and assert
+        // the same instance comes back (i.e. it is flattened at most once).
+        var pathProperty = typeof(StateGraphNode).GetProperty(
+            "Path", BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.That(pathProperty, Is.Not.Null, "StateGraphNode.Path should exist");
+
+        var target = root.Edges[0].Target;
+        var first = pathProperty.GetValue(target);
+        var second = pathProperty.GetValue(target);
+
+        Assert.That(first, Is.Not.Null);
+        Assert.That(ReferenceEquals(first, second), Is.True,
+            "the reconstructed path must be memoized and returned by reference");
+    }
+}

--- a/nuget/Microsoft.Accordant.Cli.nuspec
+++ b/nuget/Microsoft.Accordant.Cli.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Microsoft.Accordant.Cli</id>
-    <version>0.1.6</version>
+    <version>0.1.7</version>
     <authors>Microsoft</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>

--- a/nuget/Microsoft.Accordant.nuspec
+++ b/nuget/Microsoft.Accordant.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Microsoft.Accordant</id>
-    <version>0.1.6</version>
+    <version>0.1.7</version>
     <authors>Microsoft</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">MIT</license>


### PR DESCRIPTION
…azy driver

Introduces an optional lazy exploration mode for StateGraph.ExploreStateGraph so consumers (e.g. model checking) can build the reachable graph on demand and stop at the first counterexample without materializing a huge — possibly intractable — graph up front.

Rather than duplicate the traversal, both eager and lazy exploration are driven by a single StateGraphExpander:

* Successor generation is factored into one path-independent kernel (StateGraph.GenerateSuccessors); constraint filtering, depth bounding, node interning, edge de-duplication and pre/post hooks all live in the shared ExpandNode.
* The eager driver walks a worklist and stores each node's edges up front; the lazy driver expands a node the first time its Edges are accessed (StateGraphNode.EnsureExpanded). Eager nodes carry no back-reference to the expander so they never self-recompute.
* The root->node traversal path and the discovery depth are both read from the node itself, reconstructed from per-node discovery back-pointers (DiscoveredFrom/DiscoveredVia). The path is flattened at most once and memoized (StateGraphNode.Path), and shared structurally across descendants. Consequently a given node is expanded with an identical path and depth in either mode, and neither driver has to thread that context.

Adds base-project tests: LazyEagerEquivalenceTests (randomized graphs assert eager and lazy produce identical unbounded graphs / hooks, and that bounded graphs are subgraphs of the unbounded one) and StateGraphPathTests (eager and lazy hand each node the identical, well-formed, prefix-closed path, and the reconstructed path is memoized).